### PR TITLE
Add KernelGen skills for MCP-driven GPU kernel generation

### DIFF
--- a/kernelgen-mcp/LICENSE.txt
+++ b/kernelgen-mcp/LICENSE.txt
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      OpenPGP-compatible signature of your completed statement.
+
+   Copyright 2026 BAAI (Beijing Academy of Artificial Intelligence)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kernelgen-mcp/README.md
+++ b/kernelgen-mcp/README.md
@@ -1,0 +1,135 @@
+# kernelgen-flagos: Unified GPU Kernel Operator Generation
+
+[中文版](README_zh.md)
+
+## Overview
+
+`kernelgen-flagos` is a unified AI coding skill that generates GPU kernel operators via the `kernelgen-mcp` MCP service. It automatically detects the target repository type and dispatches to the appropriate specialized workflow.
+
+### Problem Statement
+
+Writing high-performance GPU kernels is complex and error-prone. Different projects (FlagGems, vLLM, custom Triton repos) each have unique conventions for operator implementation, testing, and registration. Previously, users needed to install separate skills for each project type.
+
+This unified skill bundles **four sub-skills** into one package, so users only need a single install:
+
+| Sub-skill | Purpose |
+|---|---|
+| **kernelgen-general** | Generate GPU kernels for any Python/Triton repository |
+| **kernelgen-for-flaggems** | Specialized for FlagGems (`pointwise_dynamic`, `_FULL_CONFIG`, categorized tests) |
+| **kernelgen-for-vllm** | Specialized for vLLM (SPDX headers, `init_logger`, `@triton.autotune`, custom op registration) |
+| **kernelgen-submit-feedback** | Submit bug reports via GitHub Issues or email |
+
+### Usage
+
+```bash
+# Generate a kernel operator (auto-detects repo type)
+/kernelgen-flagos relu
+
+# Generate with explicit function type
+/kernelgen-flagos rms_norm --func-type normalization
+
+# Generate for any operator
+/kernelgen-flagos silu_and_mul
+```
+
+The skill will automatically:
+- Detect if you're in a **FlagGems** repo and use the FlagGems-specific workflow
+- Detect if you're in a **vLLM** repo and use the vLLM-specific workflow
+- Otherwise, use the **general-purpose** workflow with dynamic repo discovery
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `operator_name` | Yes | — | Operator name in snake_case (e.g. `relu`, `rms_norm`, `silu_and_mul`) |
+| `--func-type` | No | Auto-inferred | Function type category (varies by detected repo type) |
+
+### Feedback
+
+If you encounter any issues during generation, say "submit feedback" or "report a bug" and the skill will guide you through submitting a GitHub issue or email.
+
+---
+
+## How It Works
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Phase 1   Detect repository type                        │
+│            ├── FlagGems? → kernelgen-for-flaggems.md     │
+│            ├── vLLM?     → kernelgen-for-vllm.md        │
+│            └── Other?    → kernelgen-general.md          │
+│                                                          │
+│  Phase 2   Execute the selected sub-skill workflow       │
+│            (environment check → MCP generation →         │
+│             code adaptation → testing → benchmarking)    │
+│                                                          │
+│  Phase 3   Feedback handling (on demand)                 │
+│            → kernelgen-submit-feedback.md                │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Directory Structure
+
+```
+skills/kernelgen/
+├── SKILL.md                       # Unified entry point (routing logic)
+├── kernelgen-general.md           # General-purpose sub-skill
+├── kernelgen-for-flaggems.md      # FlagGems-specific sub-skill
+├── kernelgen-for-vllm.md          # vLLM-specific sub-skill
+├── kernelgen-submit-feedback.md   # Feedback submission sub-skill
+├── LICENSE.txt                    # Apache 2.0 license
+├── README.md                      # This document (English)
+└── README_zh.md                   # Chinese version
+```
+
+---
+
+## File Descriptions
+
+### `SKILL.md`
+
+The unified entry point. Contains routing logic that auto-detects the repository type (FlagGems, vLLM, or generic) and reads the appropriate sub-skill file to execute.
+
+### `kernelgen-general.md`
+
+Full 10-step workflow for generating GPU kernel operators in any Python/Triton repository. Includes dynamic repo structure discovery, convention detection, and adaptive code placement.
+
+### `kernelgen-for-flaggems.md`
+
+9-step workflow specialized for FlagGems repositories. Handles `pointwise_dynamic` wrappers, promotion methods, `_FULL_CONFIG` registration, categorized test files, and FlagGems-specific conventions.
+
+### `kernelgen-for-vllm.md`
+
+9-step workflow specialized for vLLM repositories. Handles SPDX license headers, `vllm.logger.init_logger`, `@triton.autotune`, custom op registration, and vLLM directory conventions.
+
+### `kernelgen-submit-feedback.md`
+
+Feedback submission workflow. Collects bug reports with auto-detected environment info and submits via GitHub Issues (`gh` CLI) or email fallback.
+
+---
+
+## Usage in FlagOS Skills Repository
+
+### Quick Install (via npx)
+
+```bash
+# Install the unified kernelgen skill (includes all sub-skills)
+npx skills add flagos-ai/skills --skill kernelgen -a claude-code
+
+# Or install all Flagos skills at once
+npx skills add flagos-ai/skills -a claude-code
+```
+
+### Manual Install
+
+```bash
+# From your project root
+mkdir -p .claude/skills
+cp -r <path-to-this-repo>/skills/kernelgen .claude/skills/
+```
+
+---
+
+## License
+
+This project is licensed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt) for details.

--- a/kernelgen-mcp/README_zh.md
+++ b/kernelgen-mcp/README_zh.md
@@ -1,0 +1,109 @@
+# kernelgen-flagos：统一 GPU 算子生成技能
+
+## 概述
+
+`kernelgen-flagos` 是一个统一的 AI 编程技能，通过 `kernelgen-mcp` MCP 服务生成 GPU 算子。它自动检测目标仓库类型，并分发到相应的专用工作流。
+
+### 解决的问题
+
+编写高性能 GPU 算子复杂且容易出错。不同项目（FlagGems、vLLM、自定义 Triton 仓库）各自有独特的算子实现规范、测试模式和注册系统。此前，用户需要分别安装多个技能。
+
+本统一技能将 **四个子技能** 打包为一个，用户只需安装一次：
+
+| 子技能 | 用途 |
+|---|---|
+| **kernelgen-general** | 为任意 Python/Triton 仓库生成 GPU 算子 |
+| **kernelgen-for-flaggems** | FlagGems 专用（`pointwise_dynamic`、`_FULL_CONFIG`、分类测试） |
+| **kernelgen-for-vllm** | vLLM 专用（SPDX 头、`init_logger`、`@triton.autotune`、自定义算子注册） |
+| **kernelgen-submit-feedback** | 通过 GitHub Issues 或邮件提交 bug 报告 |
+
+### 使用方式
+
+```bash
+# 生成算子（自动检测仓库类型）
+/kernelgen-flagos relu
+
+# 指定函数类型
+/kernelgen-flagos rms_norm --func-type normalization
+
+# 生成任意算子
+/kernelgen-flagos silu_and_mul
+```
+
+技能会自动：
+- 检测到 **FlagGems** 仓库 → 使用 FlagGems 专用工作流
+- 检测到 **vLLM** 仓库 → 使用 vLLM 专用工作流
+- 其他情况 → 使用通用工作流，动态发现仓库结构
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `operator_name` | 是 | — | snake_case 格式的算子名称（如 `relu`、`rms_norm`、`silu_and_mul`） |
+| `--func-type` | 否 | 自动推断 | 函数类型分类（根据检测到的仓库类型有所不同） |
+
+### 反馈
+
+在生成过程中遇到任何问题，只需说"提交反馈"或"报告 bug"，技能会引导你通过 GitHub issue 或邮件提交反馈。
+
+---
+
+## 工作原理
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  阶段 1   检测仓库类型                                     │
+│           ├── FlagGems? → kernelgen-for-flaggems.md      │
+│           ├── vLLM?     → kernelgen-for-vllm.md         │
+│           └── 其他?     → kernelgen-general.md           │
+│                                                          │
+│  阶段 2   执行选定的子技能工作流                            │
+│           （环境检查 → MCP 生成 →                          │
+│            代码适配 → 测试 → 性能基准测试）                  │
+│                                                          │
+│  阶段 3   反馈处理（按需）                                  │
+│           → kernelgen-submit-feedback.md                  │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 目录结构
+
+```
+skills/kernelgen-flagos/
+├── SKILL.md                       # 统一入口（路由逻辑）
+├── kernelgen-general.md           # 通用子技能
+├── kernelgen-for-flaggems.md      # FlagGems 专用子技能
+├── kernelgen-for-vllm.md          # vLLM 专用子技能
+├── kernelgen-submit-feedback.md   # 反馈提交子技能
+├── LICENSE.txt                    # Apache 2.0 许可证
+├── README.md                      # 英文文档
+└── README_zh.md                   # 本文档（中文版）
+```
+
+---
+
+## 安装方式
+
+### 快速安装（通过 npx）
+
+```bash
+# 安装统一的 kernelgen 技能（包含所有子技能）
+npx skills add flagos-ai/skills --skill kernelgen-flagos -a claude-code
+
+# 或一次安装所有 Flagos 技能
+npx skills add flagos-ai/skills -a claude-code
+```
+
+### 手动安装
+
+```bash
+# 在项目根目录下
+mkdir -p .claude/skills
+cp -r <path-to-this-repo>/skills/kernelgen-flagos .claude/skills/
+```
+
+---
+
+## 许可证
+
+本项目基于 Apache 2.0 许可证。详见 [LICENSE.txt](LICENSE.txt)。

--- a/kernelgen-mcp/SKILL.md
+++ b/kernelgen-mcp/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: kernelgen-flagos
+description: >
+  Unified GPU kernel operator generation skill. Automatically detects the target repository type
+  (FlagGems, vLLM, or general Python/Triton) and dispatches to the appropriate specialized
+  sub-skill. Also includes a feedback submission sub-skill for bug reports. Use this skill when
+  the user wants to generate a GPU kernel operator, create a Triton kernel, or says things like
+  "generate an operator", "create a kernel for X", or "/kernelgen-flagos". This single skill replaces
+  the need to install kernelgen-general, kernelgen-for-flaggems, kernelgen-for-vllm, and
+  kernelgen-submit-feedback separately.
+argument-hint: "<operator_name> [--func-type <type>]"
+user-invokable: true
+compatibility: "Python 3.8+, PyTorch with CUDA, Triton"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: gpu-kernel-generation
+  tags: [kernelgen, triton, gpu, mcp, operator-generation, flaggems, vllm, feedback]
+allowed-tools:
+  - Bash
+  - Bash(gh:*)
+  - Bash(python:*)
+  - Bash(python3:*)
+  - Bash(command:*)
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# kernelgen-flagos — Unified GPU Operator Generation Skill
+
+This is a **unified entry point** that bundles four sub-skills into one:
+
+| Sub-skill file | Purpose |
+|---|---|
+| `kernelgen-general.md` | Generate GPU kernels for **any** Python/Triton repository |
+| `kernelgen-for-flaggems.md` | Specialized generation for **FlagGems** repositories |
+| `kernelgen-for-vllm.md` | Specialized generation for **vLLM** repositories |
+| `kernelgen-submit-feedback.md` | Submit bug reports and feedback via GitHub or email |
+
+All sub-skill files are located in the **same directory** as this `SKILL.md` file.
+
+---
+
+## Routing Protocol — Follow This BEFORE Doing Anything Else
+
+### Phase 1: Detect Repository Type
+
+Use the Glob tool to check for project identity files in the current working directory:
+
+```
+Glob: pyproject.toml
+Glob: setup.py
+Glob: setup.cfg
+```
+
+Then use the Read tool to read whichever file exists. Determine the **project name** from
+the file contents (e.g., `name = "flag_gems"` in pyproject.toml, or `name='vllm'` in setup.py).
+
+Also use the Glob tool to check for characteristic directory structures:
+
+**FlagGems indicators** (match ANY):
+- `src/flag_gems/` directory exists
+- Project name is `flag_gems` or `flag-gems` or `FlagGems`
+- `import flag_gems` appears in test files
+
+**vLLM indicators** (match ANY):
+- `vllm/` directory exists at the repo root (with `vllm/__init__.py`)
+- Project name is `vllm`
+- `csrc/` directory exists alongside `vllm/`
+
+### Phase 2: Dispatch to Sub-skill
+
+Based on the detection result, use the **Read tool** to read the appropriate sub-skill file
+from this skill's directory, then **follow the instructions in that file exactly**.
+
+**To locate the sub-skill files**: They are in the same directory as this SKILL.md. Use the
+Glob tool to find the path:
+
+```
+Glob: **/skills/kernelgen-flagos/kernelgen-general.md
+```
+
+Then use the Read tool to read the matched path.
+
+#### Decision Table
+
+| Detection Result | Action |
+|---|---|
+| FlagGems repository detected | Read `kernelgen-for-flaggems.md` and follow it |
+| vLLM repository detected | Read `kernelgen-for-vllm.md` and follow it |
+| Neither detected (or unknown) | Read `kernelgen-general.md` and follow it |
+| User reports a bug or requests feedback submission | Read `kernelgen-submit-feedback.md` and follow it |
+
+**Important rules:**
+1. **Always detect first, dispatch second.** Never skip detection.
+2. **Read the entire sub-skill file** before starting execution — do not partially read it.
+3. **Follow the sub-skill instructions exactly** as if they were the main SKILL.md. All steps,
+   rules, and protocols in the sub-skill apply fully.
+4. **Do not mix sub-skills.** Once you dispatch to a sub-skill, follow it to completion.
+5. If the user explicitly requests a specific sub-skill (e.g., "use the FlagGems version"),
+   honor that request regardless of auto-detection results.
+6. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
+   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   wrappers, or operator implementations yourself. If MCP is not configured, not reachable,
+   or fails after all retries, STOP and report the issue — do NOT fall back to writing code
+   manually.
+
+### Phase 3: Feedback Handling
+
+At **any point** during the workflow, if the user reports a bug, says something is broken,
+or asks to submit feedback about the skill:
+
+1. Use the Read tool to read `kernelgen-submit-feedback.md` from this skill's directory.
+2. Follow the feedback submission workflow described in that file.
+3. After feedback is submitted, ask the user if they want to continue with the operator
+   generation workflow or stop.
+
+---
+
+## Quick Reference for Users
+
+```bash
+# Generate a kernel operator (auto-detects repo type)
+/kernelgen-flagos relu
+
+# Generate with explicit function type
+/kernelgen-flagos rms_norm --func-type normalization
+
+# The skill will automatically:
+# - Detect if you're in a FlagGems repo → use FlagGems-specific workflow
+# - Detect if you're in a vLLM repo → use vLLM-specific workflow
+# - Otherwise → use the general-purpose workflow
+```
+
+If you encounter any issues during generation, just say "submit feedback" or "report a bug"
+and the skill will guide you through the feedback submission process.

--- a/kernelgen-mcp/kernelgen-for-flaggems.md
+++ b/kernelgen-mcp/kernelgen-for-flaggems.md
@@ -1,0 +1,1152 @@
+
+# KernelGen Skill — Generate FlagGems Operators via MCP
+
+You are an expert at generating GPU kernel operators for the FlagGems project using the `kernelgen-mcp` MCP service.
+
+**Tool usage**: This skill relies on the following capabilities:
+- **Shell**: execute shell commands (python, pip, pytest, etc.) via the Bash/shell tool
+- **Read**: read files from the codebase
+- **Write / Edit**: create or modify files
+- **Grep**: search file contents
+- **Glob**: find files by pattern
+- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+
+> **MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+
+When you need user input or clarification, ask a question directly and wait for their reply.
+Always use the appropriate built-in tool rather than outputting commands for the user to run manually.
+
+## Execution Rules
+
+1. **Follow the steps in order**. Never jump ahead.
+2. **Never skip Step 2** (operator existence check) — always verify before generating.
+3. **Do not generate or write any code before Step 4** (MCP call). Steps 0–3 are preparation only.
+4. **Always confirm with the user before destructive actions**.
+5. **Report progress to the user when entering each step**.
+6. **Never fabricate repository files or paths**.
+7. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
+   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
+   relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 4,
+   STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
+   The MCP service produces optimized, tested code that manual writing cannot match.
+
+---
+
+## FlagGems Project Layout Reference
+
+The FlagGems project has three operator locations and corresponding test/benchmark locations:
+
+### Operator Locations
+| Location | Path | Description |
+|---|---|---|
+| **Core (src)** | `src/flag_gems/ops/<kernel_name>.py` | Mature, production-quality operators. Uses `pointwise_dynamic` decorators for pointwise ops. Registered in `_FULL_CONFIG` for aten dispatch. |
+| **Experimental** | `src/flag_gems/experimental_ops/<kernel_name>.py` | New/experimental operators. Uses raw Triton pointer-based style (self-contained, no `pointwise_dynamic`). NOT registered in `_FULL_CONFIG`. |
+| **Backend** | `src/flag_gems/runtime/backend/_<vendor>/ops/<kernel_name>.py` | Non-NVIDIA chip-specific operators. Vendor names: `_ascend` (Huawei), `_cambricon`, `_hygon` (DCU), `_mthreads` (Moore), `_iluvatar` (Tianshu), `_metax`, `_amd`, `_kunlunxin`, `_arm`, `_aipu`. |
+
+### Test Locations
+| Operator Location | Accuracy Tests | Performance Tests |
+|---|---|---|
+| **Core (src)** | `tests/test_<category>_ops.py` (append to existing file) | `benchmark/test_<category>_perf.py` (append to existing file) |
+| **Experimental** | `experimental_tests/<kernel_name>_test.py` (standalone file) | Same file as accuracy test (includes benchmark function) |
+| **Backend** | Backend-specific test directory (follow existing pattern per vendor) | Backend-specific benchmark directory |
+
+### Test Style Conventions (CRITICAL)
+
+**`tests/` folder style** — uses `flag_gems.use_gems()` context manager and calls ops via `torch.<op>()`:
+```python
+import flag_gems
+from .accuracy_utils import gems_assert_close, to_reference, POINTWISE_SHAPES, FLOAT_DTYPES
+
+def test_accuracy_<kernel_name>(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+    ref_out = <torch_call>(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.<kernel_name>(inp)
+    gems_assert_close(res_out, ref_out, dtype)
+```
+
+**`experimental_tests/` folder style** — uses direct import from `flag_gems.experimental_ops`:
+```python
+import flag_gems
+from flag_gems.experimental_ops.<kernel_name> import <kernel_name> as gems_op
+
+def test_<kernel_name>_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = to_reference(x)
+    ref_out = torch.ops.aten.<kernel_name>(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_op(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+```
+
+**IMPORTANT**: Before writing a test, always read 1-2 existing test files in the **same folder** to match the exact style (imports, utility functions, assertion helpers, parametrize decorators, etc.). Never mix styles between folders.
+
+### Decorator Conventions
+
+**Core ops (`src/flag_gems/ops/`)** use FlagGems decorators:
+- `@pointwise_dynamic(promotion_methods=...)` + `@triton.jit` — for pointwise ops
+- The kernel receives **scalar elements** (not pointers), no `tl.load`/`tl.store`
+- See `src/flag_gems/ops/abs.py`, `src/flag_gems/ops/sigmoid.py` for examples
+
+**Experimental ops (`src/flag_gems/experimental_ops/`)** use raw Triton style:
+- `@triton.jit` only — standard Triton pointer-based kernels
+- The kernel receives **pointers**, uses `tl.load`/`tl.store`, `BLOCK_SIZE`, masks
+- Self-contained, no `flag_gems.utils` imports needed
+- See `src/flag_gems/experimental_ops/abs.py` for example
+
+**When adapting MCP output**: The MCP always generates raw pointer-based Triton code.
+- For **core ops**: MUST rewrite to `pointwise_dynamic` style — strip all pointer logic
+- For **experimental ops**: Keep the MCP Triton code mostly as-is (it's already pointer-based)
+- For **backend ops**: Follow the existing backend vendor patterns
+
+---
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Run the following diagnostic command:
+
+```bash
+python -c "import torch; import triton; import flag_gems; print('torch', torch.__version__); print('triton', triton.__version__); print('flag_gems', flag_gems.__version__); print('device', flag_gems.device)"
+```
+
+**If any import fails**, identify what's missing and use the shell tool to install it:
+
+| Missing package | Install command |
+|---|---|
+| `torch` | Do NOT auto-install. Ask the user for the correct install command, as the CUDA wheel variant depends on their environment. |
+| `triton` | `pip install triton` |
+| `flag_gems` | `pip install -e .` from the repo root, or `pip install flag_gems` |
+| `pytest` | `pip install pytest` |
+| `numpy` | `pip install numpy` |
+| `scipy` | `pip install scipy` |
+| `pyyaml` | `pip install pyyaml` |
+| `packaging` | `pip install packaging` |
+
+If `torch` is missing or has no CUDA support, run a separate GPU diagnostic:
+
+```bash
+python -c "import torch; print('cuda_version:', torch.version.cuda); print('cuda_available:', torch.cuda.is_available())"
+```
+
+Then diagnose:
+- If `torch.version.cuda` is `None` → torch is a CPU-only build. Ask the user to reinstall with CUDA.
+- If `torch.version.cuda` has a value but `torch.cuda.is_available() == False` → CUDA build but no GPU
+  detected. Warn the user that GPU tests will fail and ask how to proceed.
+
+If `flag_gems` is not installed, first verify `pyproject.toml` or `setup.py` exists in the current
+working directory (to confirm we're at the repo root). If found, run `pip install -e .`. If not
+found, ask the user for the correct repo root path.
+
+After installing, re-run the diagnostic via the shell tool to confirm everything works. Only proceed when all imports succeed.
+
+### 0b. Check MCP Availability
+
+Verify that the `kernelgen-mcp` MCP server is configured and reachable.
+
+Use the Read tool to read `.claude/settings.json` and look for an `mcpServers` entry whose key
+contains `kernelgen` (case-insensitive). If the file does not exist, treat it as "MCP not configured".
+
+**If the MCP server is NOT configured**, stop and print the following message to the user, then
+wait for the user to provide the URL and JWT token:
+
+```
+The kernelgen-mcp service is not yet configured. Please follow these steps:
+
+1. Visit https://kernelgen.flagos.io/ to register and obtain a JWT Token.
+2. Add the following MCP configuration to `.claude/settings.json` (replace <YOUR_URL> and <YOUR_JWT_TOKEN> with actual values):
+
+{
+  "mcpServers": {
+    "kernelgen-mcp": {
+      "type": "sse",
+      "url": "<YOUR_URL>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+      }
+    }
+  }
+}
+
+3. After configuration is complete, please re-run this command.
+```
+
+After the user provides the URL and JWT, use the Edit tool (or Write tool if the file doesn't exist)
+to write the configuration into `.claude/settings.json`, merging with any existing content. Then proceed.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name (e.g., `relu`, `softmax`, `gelu`, `layer_norm`).
+  Prefer names exactly as defined in `torch.ops.aten` (e.g., `relu`, `silu`, `neg`),
+  since registration uses the aten name.
+- `torch_call`: the actual Python call to invoke this op on a tensor. This is NOT always
+  `torch.<kernel_name>`. Determine it as follows:
+  1. If `torch.<kernel_name>` exists (`hasattr(torch, '<kernel_name>')` is True) → use `torch.<kernel_name>`
+  2. If not, check `torch.nn.functional.<kernel_name>` (e.g., `torch.nn.functional.layer_norm`)
+  3. If not, check `torch.special.<kernel_name>` or `torch.linalg.<kernel_name>`
+  4. As a last resort, use `torch.ops.aten.<kernel_name>.default`
+  Do NOT use `torch._C._nn` — it is an internal API that can break across PyTorch versions.
+  **Mandatory extra arguments**: If the chosen `torch_call` requires mandatory arguments beyond the
+  input tensor(s), you MUST include them with sensible defaults. Common cases:
+  - `torch.nn.functional.softmax(x, dim=-1)`
+  - `torch.nn.functional.log_softmax(x, dim=-1)`
+  - `torch.nn.functional.layer_norm(x, normalized_shape=x.shape[-1:])`
+  - `torch.nn.functional.dropout(x, p=0.5, training=False)`
+  - `torch.nn.functional.normalize(x, dim=-1)`
+  When in doubt, check the existing tests in the repo or the PyTorch docs for required arguments.
+  Omitting mandatory arguments (e.g., `torch.nn.functional.softmax(x)` without `dim`) will cause
+  runtime errors.
+  Store `<torch_call>` (including any mandatory extra arguments) — it will be used in tests and
+  benchmarks wherever the reference op is needed.
+- `func_desc`: what the operator does
+- `func_type`: one of the following categories (aligned with FlagGems test structure).
+  **Auto-infer from the operator signature when possible:**
+  - If 1 tensor input, no dim arg → `unary_pointwise`
+  - If operator has >=2 tensor inputs, no dim arg → `binary_pointwise`
+  - If has a `dim` argument → `reduction`
+  - If name contains `norm`, `softmax` (also matches `log_softmax`), `rmsnorm`, or `batchnorm` → `normalization`
+  - If name is `mm`, `matmul`, `bmm`, `addmm` → `blas`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous. Categories:
+  - `unary_pointwise` — single-input elementwise ops (relu, sigmoid, abs, etc.)
+  - `binary_pointwise` — two-input elementwise ops (add, mul, etc.)
+  - `reduction` — ops that reduce dimensions (sum, mean, max, etc.)
+  - `normalization` — norm ops (layer_norm, batch_norm, group_norm, etc.)
+  - `blas` — matrix operations (matmul, mm, bmm, etc.)
+  - `other` — everything else (indexing, special, etc.)
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+- `target_device`: determine target device from user context:
+  - If user mentions NVIDIA/英伟达/nv or doesn't specify → `"nvidia"` (default)
+  - If user mentions 华为/昇腾/Ascend → `"huawei"`
+  - If user mentions 海光/Hygon/DCU → `"haiguang"`
+  - If user mentions 摩尔/Moore/摩尔线程 → `"moore"`
+  - If user mentions 天数/Tianshu/天数智芯 → `"tianshu"`
+  - If user mentions 寒武纪/Cambricon → `"cambricon"`
+
+If the operator name is ambiguous, first check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` (torch.ops.aten) |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| square | `pow` (exp=2) |
+| cube | `pow` (exp=3) |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+| logarithm / ln | `log` |
+| exponential | `exp` |
+| hyperbolic_tangent | `tanh` |
+| square_root | `sqrt` |
+| cube_root | `cbrt` |
+| inverse_sqrt | `rsqrt` |
+| reciprocal / inverse | `reciprocal` |
+| minimum | `min` |
+| maximum | `max` |
+| floor_divide | `floor_divide` |
+| modulo / mod | `remainder` |
+
+If the alias is not in this table, ask the user to clarify.
+
+After determining `func_type`, derive the `<category>` value used for test/benchmark file paths:
+
+| func_type | category (for file paths) |
+|---|---|
+| `unary_pointwise` | `unary_pointwise` |
+| `binary_pointwise` | `binary_pointwise` |
+| `reduction` | `reduction` |
+| `normalization` | `norm` |
+| `blas` | `blas` |
+| `other` | `special` |
+
+Store this `<category>` value — it determines which test and benchmark files to modify.
+
+## Step 1.5: Determine Placement (NEW — CRITICAL DECISION)
+
+Based on the user's request and the operator analysis, determine `<placement>`:
+
+### Decision Rules
+
+1. **Backend placement** (`backend`): If `target_device` is NOT `"nvidia"` (i.e., non-NVIDIA chip), the operator goes into the backend directory:
+   - Operator: `src/flag_gems/runtime/backend/_<vendor>/ops/<kernel_name>.py`
+   - Tests: Follow the existing backend vendor test pattern (read existing tests in that vendor's directory first)
+
+2. **Core placement** (`core`): If the user explicitly asks to **modify/replace an existing core operator** in `src/flag_gems/ops/`, or the user specifically says "add to src/core":
+   - Operator: `src/flag_gems/ops/<kernel_name>.py`
+   - Tests: `tests/test_<category>_ops.py` (append to existing file)
+   - Benchmarks: `benchmark/test_<category>_perf.py` (append to existing file)
+
+3. **Experimental placement** (`experimental`) — **DEFAULT for new operators**:
+   - New operators should go here unless the user explicitly requests core placement
+   - Operator: `src/flag_gems/experimental_ops/<kernel_name>.py`
+   - Tests: `experimental_tests/<kernel_name>_test.py` (standalone file)
+   - Benchmarks: Included in the same test file
+
+### Ask the user if ambiguous
+
+If the placement is not obvious from context, ask:
+- "This is a new operator. I recommend placing it in `experimental_ops/` (experimental). Would you prefer to place it in `src/flag_gems/ops/` (core) instead?"
+- If the user mentions a non-NVIDIA chip, confirm: "I'll place this in the `_<vendor>` backend directory. Is that correct?"
+
+Store `<placement>` as one of: `core`, `experimental`, `backend`.
+
+## Step 2: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase for existing implementations:
+
+1. **Core ops**: Use the Glob tool to check for `src/flag_gems/ops/<kernel_name>.py`
+2. **Experimental ops**: Use the Glob tool to check for `src/flag_gems/experimental_ops/<kernel_name>.py`
+3. **Backend ops**: If `<placement>` is `backend`, check `src/flag_gems/runtime/backend/_<vendor>/ops/<kernel_name>.py`
+4. **Registration**: Use the Grep tool to search `src/flag_gems/ops/__init__.py` and `src/flag_gems/__init__.py` for the op name
+5. **Aten registration**: Use the Grep tool to search for `torch.ops.aten.<kernel_name>` in the codebase (some registrations use the aten op reference instead of string names)
+6. **Tests**: Use the Grep tool to search `tests/test_*_ops.py` and `experimental_tests/<kernel_name>_test.py` for the op name
+7. **Benchmarks**: Use the Grep tool to search `benchmark/test_*_perf.py` for the op name in `forward_operations`
+
+### If the operator already exists
+
+Present findings to the user and ask them to choose one of the following:
+
+**Option A — Skip generation**: The operator already exists; do nothing.
+
+**Option B — Replace existing**: Overwrite the current implementation with MCP-generated code
+(adapted to FlagGems conventions). The file stays in its **current location** (core stays in core, experimental stays in experimental).
+
+**Option C — Create experimental variant (side-by-side)**: Generate the operator under the same
+name in `experimental_ops/` so it coexists with the original. This will:
+  - Create `src/flag_gems/experimental_ops/<kernel_name>.py`
+  - Create a standalone test in `experimental_tests/<kernel_name>_test.py`
+  - Include a perf benchmark in that same test file
+  - Do **NOT** register it in `_FULL_CONFIG` (it won't override the aten dispatch)
+
+Only proceed to Step 3 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 3. Use `<placement>` determined in Step 1.5.
+
+## Step 3: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials that improve generation quality:
+
+1. **Read similar operator code** from the codebase. Choose based on `<placement>`:
+   - **Core placement** — read from `src/flag_gems/ops/`:
+     - Unary pointwise → read `src/flag_gems/ops/abs.py` or `src/flag_gems/ops/sigmoid.py`
+     - Binary pointwise → read `src/flag_gems/ops/add.py`
+     - Reduction → read `src/flag_gems/ops/sum.py` or `src/flag_gems/ops/mean.py`
+     - Normalization → read `src/flag_gems/ops/layer_norm.py`
+     - BLAS → read `src/flag_gems/ops/mm.py`
+   - **Experimental placement** — read from `src/flag_gems/experimental_ops/`:
+     - Read `src/flag_gems/experimental_ops/abs.py` or a similar experimental op
+   - **Backend placement** — read existing ops in the target vendor directory
+
+2. **Read the test pattern** from the matching test location:
+   - **Core**: read `tests/test_<category>_ops.py` — note the import style, utility functions, parametrize patterns
+   - **Experimental**: read an existing `experimental_tests/<some_op>_test.py` — note the direct import style, `to_reference()`, `GenericBenchmark` usage
+   - **Backend**: read existing tests in the backend vendor directory
+
+3. **Note the decorators used** in similar operators:
+   - Core pointwise ops use `@pointwise_dynamic(promotion_methods=...)` + `@triton.jit`
+   - Experimental ops use `@triton.jit` only (raw pointer-based)
+   - Some ops may use other decorators like `@triton.autotune` — note these
+
+4. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+5. Collect all findings and **summarize into concise notes** (not full file contents) to pass as
+   the `flagos_wiki` parameter. For example:
+   - `"abs.py uses pointwise_dynamic with DEFAULT promotion, returns tl.abs(x)"`
+   - `"sigmoid.py uses INT_TO_FLOAT promotion, returns 1/(1+tl.exp(-x))"`
+   - `"test pattern: @pytest.mark.xxx, POINTWISE_SHAPES, FLOAT_DTYPES, gems_assert_close"`
+   - `"experimental test style: from flag_gems.experimental_ops.abs import abs as gems_abs, uses torch.ops.aten.abs for reference"`
+
+   If the `mcp__kernelgen-mcp__generate_operator` tool supports a `flagos_wiki` (or similarly named
+   `context`/`references`) parameter, pass the collected notes. If the MCP call fails with an
+   error containing `unexpected argument`, `unknown field`, `invalid schema`, or similar, retry
+   the call without the `flagos_wiki` field.
+
+## Step 4: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above, including the
+`flagos_wiki` list for reference context.
+
+If `<placement>` is `backend` and target device is not nvidia, pass the `device` parameter to the
+MCP call (e.g., `device="huawei"` for Ascend).
+
+**Set the iteration counter**: `iteration_count = 1`. This tracks total MCP calls for the final report.
+
+The MCP returns four code blocks:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+## Step 4.5: MCP Report Review
+
+If the MCP response includes test results (accuracy test reports, benchmark/speedup reports),
+present them to the user **in full** before proceeding to local code adaptation:
+
+```
+=== MCP Generation Test Report ===
+
+Accuracy Test Results:
+<paste the COMPLETE accuracy test output from the MCP response — do not summarize or truncate>
+
+Performance Benchmark Results:
+<paste the COMPLETE benchmark/speedup output from the MCP response — do not summarize or truncate>
+```
+
+Then ask the user:
+
+> The MCP service has returned the above test reports from its generation environment.
+> Would you like to:
+>
+> **A — Skip local testing**: Trust the MCP reports and proceed directly to code placement
+> and summary. No local tests will be run.
+>
+> **B — Run local tests**: Run accuracy and performance tests on your local machine as well
+> to verify the results in your specific environment.
+
+Wait for the user's choice before proceeding:
+- If **A (skip local testing)**: After placing code in Step 5, skip Steps 6 and 7 (local
+  accuracy tests and benchmarks) and proceed directly to Step 8 (Summary). Use the MCP
+  report numbers for the summary.
+- If **B (run local tests)**: Proceed normally through Steps 5 → 6 → 7 → 8. Before
+  running local tests, perform the **Chip Compatibility Check** described in Step 5.5c.
+
+**If the MCP response does NOT include test reports** (only code blocks), proceed normally
+to Step 5 — local testing will be required.
+
+## Step 5: Adapt and Place Code into the FlagGems Project
+
+This is the most critical step. The generated code must be transformed to match FlagGems conventions.
+The exact placement and transformation depends on `<placement>`.
+
+---
+
+### Placement: Core (`src/flag_gems/ops/`)
+
+#### 5a. Operator Implementation → `src/flag_gems/ops/<kernel_name>.py`
+
+**Transformation rules for pointwise ops**: The MCP generator will almost always output raw
+pointer-based Triton code. For core pointwise ops, you MUST **always** rewrite it into the
+`pointwise_dynamic` elementwise style:
+- The `@triton.jit` kernel function receives **scalar elements** (not pointers)
+- `pointwise_dynamic` handles all pointer arithmetic, tiling, and masking automatically
+- The kernel only contains the elementwise math logic (e.g., `return tl.maximum(x, 0)`)
+- **Remove ALL** `tl.load()`, `tl.store()`, pointer arithmetic (`ptr + offsets`), mask logic,
+  and BLOCK_SIZE parameters — these are incompatible with `pointwise_dynamic`
+- Only keep the pure math expression that transforms input element(s) to output element(s)
+
+Examples of correct `pointwise_dynamic` kernels (keep ONLY the scalar `tl.*` math):
+```python
+# relu: return tl.maximum(x, 0)
+# exp:  return tl.exp(x)
+# silu: return x * tl.sigmoid(x)
+# add:  return x + y
+```
+
+Do NOT keep `offsets`, `mask`, `n_elements`, `BLOCK_SIZE`, or any tiling logic.
+
+**CRITICAL**: The MCP Triton code MUST NOT be copied directly for core ops. Always rewrite it
+following FlagGems `pointwise_dynamic` conventions. Never trust the raw MCP code — it will
+almost always be pointer-style which is incompatible with `pointwise_dynamic`.
+
+Use the Write tool (new file) or Edit tool (replacing existing) to create the operator file.
+
+**Unary pointwise template:**
+```python
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=<PROMOTION_METHODS>)
+@triton.jit
+def <kernel_name>_forward(x):
+    return ...
+
+
+def <kernel_name>(A):
+    logger.debug("GEMS <KERNEL_NAME> FORWARD")
+    return <kernel_name>_forward(A)
+```
+
+**Binary pointwise template:**
+```python
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=<PROMOTION_METHODS>)
+@triton.jit
+def <kernel_name>_forward(x, y):
+    return ...
+
+
+def <kernel_name>(A, B):
+    logger.debug("GEMS <KERNEL_NAME> FORWARD")
+    return <kernel_name>_forward(A, B)
+```
+
+Choose the correct template based on `func_type`. For non-pointwise ops (reduction, BLAS,
+normalization), do NOT use either template — instead read a similar existing op and follow
+its pattern.
+
+**For in-place variants**: Read an existing in-place operator (e.g., `relu.py`) to find the
+exact call pattern used in this repo, then follow it. Do NOT assume the in-place parameter
+name — it may be `out0=A`, `out=A`, or another convention. Always verify by reading an existing
+in-place operator first.
+
+Key conventions:
+- Use `pointwise_dynamic` decorator from `flag_gems.utils` for pointwise ops
+- Use `triton.jit` decorator
+- The kernel function takes raw tensor elements (not pointers) — `pointwise_dynamic` handles the boilerplate
+- **Unary ops**: kernel has one parameter `(x)`, e.g. `def relu_forward(x)`
+- **Binary ops**: kernel has two parameters `(x, y)`, e.g. `def add_forward(x, y)`
+- Promotion methods — **always read a similar existing operator first** and copy its promotion
+  method. If no similar operator exists, use these guidelines as fallback:
+  - `INT_TO_FLOAT`: ops that always produce float output (exp, log, sigmoid, tanh, sqrt, etc.)
+  - `COMPLEX_TO_FLOAT`: ops that reduce complex to real (abs)
+  - `DEFAULT`: ops that preserve input dtype (relu, neg, add, mul, clamp, etc.)
+  - **Template placeholder** `<PROMOTION_METHODS>` must expand to the full list:
+    - Unary ops: `[(0, "DEFAULT")]` or `[(0, "INT_TO_FLOAT")]`
+    - Binary ops: `[(0, "DEFAULT"), (1, "DEFAULT")]` or `[(0, "INT_TO_FLOAT"), (1, "INT_TO_FLOAT")]`
+  - **When in doubt, prefer reading the repo** — promotion behavior is subtle and repo-specific.
+- The wrapper function takes `A` as the input tensor parameter name (NOT `self`)
+- Include `logger.debug("GEMS <NAME> FORWARD")` in the wrapper
+- For non-pointwise ops (reduction, BLAS, normalization, etc.), follow the specific pattern of similar existing ops — do NOT force the `pointwise_dynamic` pattern on them
+
+#### 5b. Register the Operator
+
+Use the Edit tool to make these changes:
+
+1. **`src/flag_gems/ops/__init__.py`**: Add import and `__all__` entry (in alphabetical order):
+   ```python
+   from flag_gems.ops.<kernel_name> import <kernel_name>, <kernel_name>_
+   ```
+
+2. **`src/flag_gems/__init__.py`**: Add to `_FULL_CONFIG` tuple (in alphabetical order).
+   **IMPORTANT**: First read the existing `_FULL_CONFIG` entries to match the exact registration
+   format used by this repo. Different versions may use different styles:
+   - String style: `("relu", relu)`
+   - Aten op style: `(torch.ops.aten.relu.default, relu)`
+   Copy the pattern from existing entries. Do NOT guess the format.
+   Insert the new entry in **alphabetical order** — do not change the order of existing entries.
+
+#### 5c. Accuracy Test → `tests/test_<category>_ops.py`
+
+Do NOT create a new test file. Use the Edit tool to add the test function to the appropriate existing test file:
+- Unary pointwise: `tests/test_unary_pointwise_ops.py`
+- Binary pointwise: `tests/test_binary_pointwise_ops.py`
+- Reduction: `tests/test_reduction_ops.py`
+- BLAS: `tests/test_blas_ops.py`
+- Norm: `tests/test_norm_ops.py`
+- Special: `tests/test_special_ops.py`
+
+**IMPORTANT — Match existing style**: Before writing the test, **read at least 2 existing test
+functions** in the target file. Ensure you match:
+- Import style (from `.accuracy_utils import ...`)
+- The `flag_gems.use_gems()` context manager pattern
+- Assertion function (`gems_assert_close` or `gems_assert_equal`)
+- `to_reference()` usage pattern
+- Parametrize decorators (`POINTWISE_SHAPES`, `FLOAT_DTYPES`, etc.)
+
+Follow the existing test pattern:
+```python
+@pytest.mark.<kernel_name>
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_<kernel_name>(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = <torch_call>(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.<kernel_name>(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+```
+
+Key conventions:
+- Use `flag_gems.device` not `"cuda"`
+- Use `to_reference()` to create reference tensors
+- Use `flag_gems.use_gems()` context manager for the FlagGems call
+- Use `gems_assert_close` or `gems_assert_equal` for comparison
+- Mark with `@pytest.mark.<kernel_name>`
+- If the marker `<kernel_name>` is not already registered, find where markers are defined
+  (check `pytest.ini`, `pyproject.toml`, or `setup.cfg`) and add it.
+- Use `POINTWISE_SHAPES`, `FLOAT_DTYPES` etc. from `accuracy_utils`
+
+#### 5d. Performance Benchmark → `benchmark/test_<category>_perf.py`
+
+Do NOT create a new benchmark file. Read the target benchmark file first, then use the Edit tool
+to append the new tuple into the existing `forward_operations` list (find the list definition and
+insert in alphabetical order). Follow the exact tuple format already used in the file.
+
+---
+
+### Placement: Experimental (`src/flag_gems/experimental_ops/`)
+
+This is the **default for new operators**.
+
+#### 5a. Operator Implementation → `src/flag_gems/experimental_ops/<kernel_name>.py`
+
+Use the Write tool to create the file. Use the **raw Triton pointer-based style** (standard for experimental ops).
+Keep the MCP-generated Triton code mostly as-is but ensure it:
+- Is self-contained (no `flag_gems.utils` imports needed, no `pointwise_dynamic`)
+- Has proper `@triton.jit` kernel with pointer args, mask, BLOCK_SIZE
+- **Has a Python wrapper function** that computes the grid and launches the kernel
+- Exports the wrapper function named `<kernel_name>` (and optionally `<kernel_name>_out`)
+
+**Ensure all kernel meta parameters (BLOCK_SIZE, etc.) are passed** — either via
+`@triton.autotune` or as explicit keyword arguments.
+
+Example structure (reference `src/flag_gems/experimental_ops/abs.py`):
+```python
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _<kernel_name>_kernel(in_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(in_ptr + offsets, mask=mask)
+    y = ...  # elementwise computation
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def <kernel_name>(x: torch.Tensor) -> torch.Tensor:
+    output = torch.empty_like(x)
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _<kernel_name>_kernel[grid](x, output, n_elements, BLOCK_SIZE=1024)
+    return output
+```
+
+#### 5b. Registration (limited)
+
+For experimental ops, do **NOT** modify `src/flag_gems/__init__.py` or `_FULL_CONFIG`.
+Optionally add an entry to `src/flag_gems/experimental_ops/__init__.py` if needed.
+
+#### 5c. Standalone Test + Benchmark → `experimental_tests/<kernel_name>_test.py`
+
+Use the Write tool to create a single self-contained test file.
+
+**IMPORTANT — Match experimental_tests/ style**: Before writing the test, **read 1-2 existing
+test files** in `experimental_tests/` (e.g., `abs_test.py`, `sigmoid_test.py`). Match their exact style:
+- Direct import: `from flag_gems.experimental_ops.<kernel_name> import <kernel_name> as gems_<kernel_name>`
+- Reference call: `torch.ops.aten.<kernel_name>(ref_x)` (not `torch.<kernel_name>`)
+- `to_reference()` with `TO_CPU` support
+- `GenericBenchmark` from `benchmark.performance_utils` for perf tests
+- `triton.testing.do_bench` for inline benchmarks
+
+Follow this pattern (adapted from existing experimental tests):
+```python
+# <KERNEL_NAME> operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.<kernel_name> import <kernel_name> as gems_<kernel_name>
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+try:
+    from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+    TO_CPU = False  # fallback
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+def to_reference(inp, upcast=False):
+    if inp is None:
+        return None
+    if TO_CPU:
+        ref_inp = inp.to("cpu")
+    else:
+        ref_inp = inp.clone()
+    if upcast:
+        if ref_inp.is_complex():
+            ref_inp = ref_inp.to(torch.complex128)
+        else:
+            ref_inp = ref_inp.to(torch.float64)
+    return ref_inp
+
+
+@pytest.mark.<kernel_name>
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_<kernel_name>_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = to_reference(x)
+    ref_out = torch.ops.aten.<kernel_name>(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_<kernel_name>(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.<kernel_name>
+def test_perf_aten_<kernel_name>():
+    def <kernel_name>_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    bench = GenericBenchmark(
+        input_fn=<kernel_name>_input_fn,
+        op_name="<kernel_name>",
+        torch_op=torch.ops.aten.<kernel_name>,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()
+```
+
+---
+
+### Placement: Backend (`src/flag_gems/runtime/backend/_<vendor>/`)
+
+#### 5a. Operator Implementation
+
+Read existing operators in `src/flag_gems/runtime/backend/_<vendor>/ops/` to understand the
+exact patterns used by this vendor. Follow the same style.
+
+#### 5b. Registration
+
+Follow the vendor's existing registration pattern (check `__init__.py` in the vendor directory).
+
+#### 5c. Tests
+
+Follow the vendor's existing test patterns. Read existing test files in the vendor's test
+directory before writing new ones.
+
+---
+
+## Step 5.5: Pre-test Validation
+
+Before running the full test suite, perform two quick checks:
+
+### 5.5a. Lint / Format Check
+
+If the repo uses linting tools (ruff, black, isort, flake8), run them on the changed files to
+catch style issues early. Use the shell tool:
+
+```bash
+# Adjust path based on <placement>
+python -m ruff check <operator_file_path> --fix
+python -m ruff format <operator_file_path>
+```
+
+If `ruff` is not installed, check for other formatters in `pyproject.toml` or `setup.cfg` and
+use those. If no linter is configured, skip this step.
+
+### 5.5b. Triton Compile Smoke Test
+
+Triton kernel compile errors only surface on first invocation (JIT compilation).
+
+**For Core placement:**
+```bash
+python -c "
+import torch, flag_gems
+for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+    for shape in [(1,), (4,), (128,), (4, 128), (0,)]:
+        inp = torch.empty(shape, dtype=dtype, device=flag_gems.device) if shape == (0,) else torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        with flag_gems.use_gems():
+            out = <SMOKE_TEST_CALL>  # e.g. torch.relu(inp)
+        print(f'Smoke test passed: {dtype}, shape={shape}')
+"
+```
+
+**For Experimental placement:**
+```bash
+python -c "
+import torch, flag_gems
+from flag_gems.experimental_ops.<kernel_name> import <kernel_name>
+for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+    for shape in [(1,), (4,), (128,), (4, 128), (0,)]:
+        inp = torch.empty(shape, dtype=dtype, device=flag_gems.device) if shape == (0,) else torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        out = <kernel_name>(inp)
+        print(f'Smoke test passed: {dtype}, shape={shape}')
+"
+```
+
+The `(0,)` shape tests the empty-tensor edge case (numel==0), which often causes kernel crashes.
+
+If this fails, read the error and fix the kernel before proceeding to Step 6.
+
+### 5.5c. Chip Compatibility Check (before local testing)
+
+Before running local tests, verify that the local hardware matches the operator's
+`target_device` (determined in Step 1). Use the Bash tool:
+
+```bash
+python - <<'PY'
+import subprocess
+try:
+    import torch
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            print(f"nvidia: {torch.cuda.get_device_name(i)}")
+    else:
+        print("No CUDA device available")
+except Exception:
+    print("torch not available")
+try:
+    r = subprocess.run(["npu-smi", "info"], capture_output=True, text=True, timeout=5)
+    if r.returncode == 0 and "NPU" in r.stdout:
+        print("huawei: Ascend NPU detected")
+except Exception:
+    pass
+try:
+    r = subprocess.run(["rocm-smi"], capture_output=True, text=True, timeout=5)
+    if r.returncode == 0:
+        kind = "haiguang" if "hygon" in r.stdout.lower() else "amd"
+        print(f"{kind}: ROCm device detected")
+except Exception:
+    pass
+PY
+```
+
+Compare detected hardware with `target_device`:
+
+| Target Device | Required Local Hardware |
+|---|---|
+| `nvidia` (default) | NVIDIA GPU |
+| `huawei` | Huawei Ascend NPU (`npu-smi`) |
+| `haiguang` | Hygon DCU (`rocm-smi` + Hygon) |
+| `moore` | Moore Threads GPU |
+| `tianshu` | Tianshu GPU |
+| `cambricon` | Cambricon MLU |
+
+**If the local hardware does NOT match the target device**, warn the user:
+
+```
+⚠️ Hardware mismatch detected:
+  - Operator target device: <target_device>
+  - Local hardware: <detected_hardware>
+
+Running tests for a <target_device> operator on <detected_hardware> hardware will likely
+fail or produce incorrect results. Please choose:
+
+  A — Skip local testing: Do not run local tests; rely on MCP test reports (if available).
+  B — Proceed anyway: Run local tests despite the mismatch (results may be unreliable).
+```
+
+If the user chooses A, skip Steps 6 and 7 and proceed to Step 8 (Summary).
+If the user chooses B, proceed with local tests but note the mismatch in the final report.
+
+## Step 6: Run Accuracy Tests
+
+Run the accuracy tests for the newly added operator.
+Assume the current working directory is the repository root.
+
+**For Core placement:**
+```bash
+python -m pytest tests/test_<category>_ops.py -m <kernel_name> -v
+```
+
+**For Experimental placement:**
+```bash
+python -m pytest experimental_tests/<kernel_name>_test.py -v -k "test_<kernel_name>"
+```
+
+**For Backend placement:**
+```bash
+# Use the vendor's test running convention (read existing CI scripts or Makefile first)
+python -m pytest <backend_test_path> -m <kernel_name> -v
+```
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` or `gems_assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 6a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Use the Read tool to examine the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Use the shell tool to re-run the tests.
+4. If the test **passes** → proceed to Step 7.
+5. If the test **still fails** → proceed to Step 6b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 6a entirely** — go directly
+to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 6b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+but add the error information to `flagos_wiki` as additional hints.
+**Increment**: `iteration_count += 1`.
+Keep `flagos_wiki` concise — maximum 10 items total. If retrying multiple times, replace
+earlier error entries rather than appending, to avoid bloating the prompt.
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6c.
+
+**Step 6c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback.
+**Increment**: `iteration_count += 1`.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6d.
+
+**Step 6d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+## Step 7: Run Performance Benchmark
+
+Run the performance benchmark.
+
+**For Core placement:**
+```bash
+python -m pytest benchmark/test_<category>_perf.py -m <kernel_name> -v
+```
+
+**For Experimental placement:**
+```bash
+python -m pytest experimental_tests/<kernel_name>_test.py -v -k "perf"
+```
+
+Look for lines in the output containing keywords like `speedup`, `latency`, `gems`, `torch`, or
+timing values. Use regex patterns to extract numbers.
+
+**Do not just copy the raw table** — always compute and report actual speedup ratios.
+
+If a speedup metric is printed directly, extract and report it. Otherwise compute:
+`speedup = torch_latency / gems_latency` (>1.0 means gems is faster).
+
+**Note**: Triton kernels are JIT-compiled on first invocation, which adds significant overhead.
+If benchmark results look unreasonably slow on the first config, check whether the benchmark
+framework includes a warmup phase. If not, the first data point may be an outlier — **if the
+first timing sample is >5x larger than the median of remaining samples, exclude it** from the
+average speedup calculation and note "first sample excluded (Triton JIT compile overhead)" in
+the report.
+
+## Step 8: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Placement: Core / Experimental / Backend (_<vendor>)
+Generation Mode: New / Replace Existing / Experimental Variant
+Operator Type: <func_type>
+Target Device: <target_device>
+
+File Changes:
+  - [New/Modified] <operator_file_path>
+  - [New/Modified] <test_file_path>
+  - [Modified] <benchmark_file_path> (if applicable)
+  - [Modified] src/flag_gems/ops/__init__.py (if core)
+  - [Modified] src/flag_gems/__init__.py (if core)
+
+Decorator Style: pointwise_dynamic / raw triton.jit / other
+Test Style: use_gems() + torch.<op>() / direct import from experimental_ops
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (shape=<S>, dtype=<D>)
+  Worst Speedup: <X.XX>x (shape=<S>, dtype=<D>)
+  (If benchmark was not run or failed, write "Incomplete" and explain why)
+
+MCP Iterations: <iteration_count> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern">
+
+Issues and Fixes: (if any)
+```
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user.
+- **If average speedup is 0.5x ~ 1.2x**, suggest optimization.
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+## Step 9: Post-Completion Actions
+
+After the summary is presented (whether based on MCP reports or local test results), perform
+the following two checks.
+
+### 9a. Chat Tool Notification
+
+If the user's task was received via a chat tool (e.g., Feishu/飞书, Discord, Slack, Teams,
+DingTalk/钉钉, WeChat Work/企业微信, Telegram, or any similar messaging platform), or if
+the user mentions sending results to a client or team, ask:
+
+> The operator generation is complete. Would you like me to prepare a message to send the
+> generated files or summary to your client/team via **<chat_tool_name>**?
+
+If the user confirms:
+1. Prepare a concise summary message including: operator name, file paths, accuracy pass
+   rate, speedup metrics, and any issues.
+2. If the chat tool has a CLI or API integration available in the environment, use it to
+   send the message directly.
+3. If no CLI/API is available, format the message as copy-paste ready text for the user.
+4. If files need to be sent, list the exact file paths the user should attach.
+
+### 9b. Git Repository PR Submission
+
+Check whether the current project is managed by a git-based hosting service:
+
+```bash
+git remote -v 2>/dev/null | head -5
+```
+
+Detect the hosting platform from the remote URL:
+- `github.com` → GitHub
+- `gitlab.com` (or self-hosted GitLab) → GitLab
+- `gitee.com` → Gitee
+- `bitbucket.org` → Bitbucket
+
+**If a git hosting platform is detected**, ask the user:
+
+> This project is hosted on **<platform>**. Would you like me to automatically create a
+> Pull Request with the generated operator code?
+
+**If the user confirms**, follow the standard PR creation workflow:
+
+1. Create a new branch: `kernelgen/<kernel_name>`
+2. Stage all changed/new files related to this operator generation (never use `git add -A`)
+3. Create a commit with a descriptive message
+4. Push the branch to the remote with `-u` flag
+5. Create the PR using the platform's CLI tool:
+
+   **For GitHub** (`gh`):
+   ```bash
+   gh pr create --title "Add <kernel_name> operator via KernelGen" --body "$(cat <<'EOF'
+   ## Summary
+   Add `<kernel_name>` operator (<func_type>) generated via KernelGen MCP service.
+
+   ## Changes
+   - [New/Modified] `<kernel_file_path>` — Triton kernel implementation
+   - [New/Modified] `<test_file_path>` — Accuracy tests
+   - [New/Modified] `<benchmark_file_path>` — Performance benchmarks
+   - [Modified] `<registration_files>` — Operator registration (if applicable)
+
+   ## Test Results
+   ### Accuracy
+   - **Pass rate**: <N>/<total> (<percentage>%)
+   - **Failed cases**: <list or "None">
+
+   ### Performance
+   - **Avg speedup**: <X.XX>x vs PyTorch reference
+   - **Best**: <X.XX>x | **Worst**: <X.XX>x
+
+   ## Generation Details
+   - **MCP iterations**: <iteration_count>
+   - **Target device**: <target_device>
+   - **Operator type**: <func_type>
+   - **Placement**: <core / experimental / backend>
+
+   ---
+   Generated by KernelGen MCP skill
+
+   EOF
+   )"
+   ```
+
+   **For Gitee / GitLab**: Provide the PR/MR creation URL and prepared description.
+
+6. Return the PR URL to the user.
+
+**If PR creation fails**, report the error, provide the branch name, and suggest manual PR
+creation with the prepared description.
+
+**If the user declines**, do nothing — changes remain as local files.
+
+## Important Notes
+
+- **`kernel_name` must match the `torch` API name** (e.g., `silu` not `swish`, `neg` not `negate`).
+  The accuracy test calls `torch.<kernel_name>(...)`, so a mismatch will cause test failures.
+- **Never overwrite existing operators** without explicit user permission (Step 2 choice)
+- **Placement determines decorator style**:
+  - Core ops → `pointwise_dynamic` for pointwise, follow existing patterns for others
+  - Experimental ops → raw `@triton.jit` pointer-based style
+  - Backend ops → follow vendor-specific patterns
+- **Placement determines test style**:
+  - Core (`tests/`) → `flag_gems.use_gems()` + `torch.<op>()`
+  - Experimental (`experimental_tests/`) → direct `from flag_gems.experimental_ops.<op> import <op>`
+  - Backend → vendor-specific test patterns
+- **Default placement for new operators is experimental** — only use core if user explicitly requests it
+- **Follow alphabetical ordering** when adding entries to `__init__.py` and `__all__`
+- **Match the existing code style** exactly — read existing files first and copy the pattern
+  (imports, logging, naming conventions, registration format, test patterns)
+- **Speedup formula**: `speedup = torch_latency / gems_latency` (values > 1.0 mean gems is faster)
+- **Always use built-in tools** (shell, Read, Write, Edit, Grep, Glob) instead of
+  outputting commands or code snippets for the user to execute manually

--- a/kernelgen-mcp/kernelgen-for-vllm.md
+++ b/kernelgen-mcp/kernelgen-for-vllm.md
@@ -1,0 +1,1174 @@
+
+# KernelGen Skill — Generate vLLM Operators via MCP
+
+You are an expert at generating GPU kernel operators for the vLLM project using the `kernelgen-mcp` MCP service.
+
+> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+
+## Execution Rules
+
+Follow these rules strictly to avoid getting lost in the multi-step workflow:
+
+1. **Follow the steps in order**: Step 0 → Step 1 → Step 2 → ... → Step 8. Never jump ahead.
+2. **Never skip Step 2** (operator existence check) — always verify before generating.
+3. **Do not generate or write any code before Step 4** (MCP call). Steps 0–3 are preparation only.
+4. **Always confirm with the user before destructive actions**: replacing files, installing packages,
+   overwriting operators.
+5. **If any step fails, stop and report the error** to the user. Do not silently skip or retry
+   with different parameters.
+6. **Report progress to the user when entering each step**. Print a short status line like
+   `Entering Step 2 — checking whether the operator already exists...` so the user knows
+   the workflow is progressing and not stuck.
+7. **Never fabricate repository files or paths**. If a required file cannot be found using the
+   Glob or Grep tools, report it to the user instead of guessing. Do not assume a file exists
+   at a path without verifying it first.
+8. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
+   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
+   relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 4,
+   STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
+   The MCP service produces optimized, tested code that manual writing cannot match.
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Use the Bash tool to run a diagnostic that checks each package independently (so one failure
+does not prevent checking the rest):
+
+```bash
+python - <<'PY'
+import importlib
+
+def check(pkg):
+    try:
+        m = importlib.import_module(pkg)
+        print(pkg, getattr(m, "__version__", "installed"))
+        return True
+    except Exception:
+        print(pkg, "NOT installed")
+        return False
+
+check("torch")
+triton_ok = check("triton")
+
+try:
+    import torch
+    print("cuda available", torch.cuda.is_available())
+    if torch.cuda.is_available():
+        print("torch.cuda version:", torch.version.cuda)
+        n = torch.cuda.device_count()
+        print("cuda devices:", n)
+        for i in range(n):
+            print(f"  cuda:{i}", torch.cuda.get_device_name(i))
+except Exception:
+    pass
+
+if triton_ok:
+    try:
+        import triton.runtime
+        print("triton runtime OK")
+    except Exception as e:
+        print("triton runtime issue:", e)
+
+check("vllm")
+check("pytest")
+check("numpy")
+
+try:
+    import subprocess
+    result = subprocess.run(["nvidia-smi"], capture_output=True, text=True, timeout=5)
+    if result.returncode == 0:
+        for line in result.stdout.splitlines()[:4]:
+            print(line)
+    else:
+        print("nvidia-smi: failed")
+except Exception:
+    print("nvidia-smi: not found")
+PY
+```
+
+**If any import fails**, stop and ask the user before installing anything. Present the missing
+packages and let the user confirm:
+
+| Missing package | Suggested install command | Notes |
+|---|---|---|
+| `torch` | `pip install torch --index-url https://download.pytorch.org/whl/cu121` | User MUST pick the correct CUDA variant (cu118/cu121/cu124). Ask which CUDA version they have. |
+| `triton` | `pip install triton` | |
+| `vllm` | `pip install -e .` (from repo root) | Confirm the current directory is the vLLM repo root first. |
+| `pytest` | `pip install pytest` | |
+| `numpy` | `pip install numpy` | |
+
+**Important**: Never install `torch` without asking the user which CUDA version they need.
+A wrong CUDA version will cause silent failures.
+
+If `torch` is installed but `torch.cuda.is_available() == False`, warn the user that GPU
+tests will fail and ask how to proceed before continuing.
+
+After the user confirms and packages are installed, re-run the diagnostic. Only proceed when
+all imports succeed.
+
+### 0b. Check MCP Availability
+
+Use the Read tool to read the file `.claude/settings.json` at the project root.
+If the file does not exist, the MCP is NOT configured.
+
+If the file exists, parse the JSON and check whether the exact key `"kernelgen-mcp"` exists
+under `mcpServers`:
+
+```
+mcpServers["kernelgen-mcp"]
+```
+
+- If the key `"kernelgen-mcp"` does **not** exist → the MCP is NOT configured.
+- If the key `"kernelgen-mcp"` **does** exist → the MCP IS configured — proceed to Step 1.
+
+Do NOT use substring matching (e.g., matching `"kernelgen"` inside `"my_kernelgen_server"`).
+Only the exact key `"kernelgen-mcp"` counts.
+
+**If the MCP server is NOT configured**, stop and tell the user:
+
+```
+kernelgen-mcp service is not configured. Please follow these steps:
+
+1. Visit https://kernelgen.flagos.io/ to register and obtain your JWT Token.
+2. Provide your MCP service URL and JWT Token to me, and I will help you write the configuration.
+
+   The final configuration format is as follows:
+   {
+     "mcpServers": {
+       "kernelgen-mcp": {
+         "type": "sse",
+         "url": "<YOUR_URL>",
+         "headers": {
+           "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+         }
+       }
+     }
+   }
+```
+
+Wait for the user to provide the URL and JWT Token. Then:
+
+1. Use the Read tool to check if `.claude/settings.json` already exists.
+2. If it exists, read its content and parse the JSON. Then:
+   - If `mcpServers` key already exists, add `"kernelgen-mcp": {...}` into it **without
+     removing any other existing MCP server entries**.
+   - If `mcpServers` key does not exist, create it with the single `kernelgen-mcp` entry.
+   - **Never overwrite the entire file** — preserve all other top-level keys.
+3. If the file does not exist, create it with just the `mcpServers` object.
+4. Use the Write tool (for new file) or Edit tool (for existing file) to save.
+5. Tell the user to **restart Claude Code** so the new MCP server is picked up, then re-run
+   the `/kernelgen_for_vllm` command.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name (e.g., `rms_norm`, `silu_and_mul`, `rotary_embedding`, `paged_attention`)
+- `func_desc`: what the operator does
+- `func_type`: one of `activation`, `norm`, `attention`, `quantization`, `moe`, `sampling`, `other`.
+  **Auto-infer from the operator signature when possible:**
+  - If name contains `relu`, `gelu`, `silu`, `swish`, `tanh`, `sigmoid` → `activation`
+  - If name contains `norm`, `rmsnorm`, `layernorm`, `batchnorm` → `norm`
+  - If name contains `attention`, `flash`, `paged` → `attention`
+  - If name contains `quant`, `awq`, `gptq`, `squeezellm` → `quantization`
+  - If name contains `moe`, `expert` → `moe`
+  - If name contains `sample`, `top_k`, `top_p` → `sampling`
+  - If operator has >=2 tensor inputs → `binary_pointwise`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous.
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+
+**Normalize `kernel_name` to snake_case** before using it anywhere:
+- `RMSNorm` → `rms_norm`
+- `SiluAndMul` → `silu_and_mul`
+- `RMS-Norm` → `rms_norm`
+- `layerNorm` → `layer_norm`
+
+This ensures consistent file naming and codebase search in subsequent steps.
+
+Check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| square | `pow` (exp=2) |
+| square_root | `sqrt` |
+| cube | `pow` (exp=3) |
+| cube_root | `cbrt` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+
+If the alias is not in this table, ask the user to clarify.
+
+**Keep `kernel_name` concise** — ideally 30 characters or fewer. If the normalized name is
+too long (e.g., `fused_swiglu_layernorm_kernel`), suggest a shorter alias to the user (e.g.,
+`fused_swiglu_ln`). Long names create unwieldy file paths like
+`tests/kernels/test_fused_swiglu_layernorm_kernel.py`.
+
+**If argument information is missing or the description is vague** (e.g., "generate a fused swiglu kernel"):
+1. Use the Grep tool to search for the operator name across the repository, specifically in:
+   - `csrc/` — CUDA kernel implementations (function signatures)
+   - `vllm/model_executor/layers/` — Python layer wrappers (forward method signatures)
+   - `vllm/kernels/` — existing Triton kernels
+   - `vllm/_custom_ops.py` — custom op registrations (full function signatures)
+2. From the search results, infer the argument names, types, and descriptions.
+3. Present the inferred signature to the user for confirmation before proceeding.
+4. **Fallback**: If no matches are found in the codebase, use a generic tensor signature as
+   the starting point and ask the user to confirm or refine:
+   ```
+   arg_names: ["x"]
+   arg_type: ["torch.Tensor"]
+   arg_descs: ["Input tensor, typically shaped (num_tokens, hidden_size) for most vLLM kernels, or (num_heads, seq_len, head_dim) for attention/rope kernels"]
+   output_arg_desc: "Output tensor of same shape as input"
+   ```
+   Note: vLLM kernels almost always use `(num_tokens, hidden_size)` as the input shape
+   convention — NOT `(batch, seq_len, hidden)`. Use 2D shapes by default.
+5. If the operator is truly ambiguous even after presenting the fallback, stop and ask
+   the user to provide the full signature.
+
+## Step 2: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase using the Glob and Grep tools:
+
+1. **Triton kernels**: Use `Glob("vllm/kernels/**/*<kernel_name>*")` to find Triton-based kernel files.
+2. **Triton kernels (alt)**: Use `Glob("vllm/triton_kernels/**/*<kernel_name>*")` — some kernels like rms_norm, silu_and_mul live here.
+3. **CUDA kernels**: Use `Glob("csrc/**/*<kernel_name>*")` to find CUDA kernel files.
+4. **Attention backends**: Use `Glob("vllm/attention/**/*<kernel_name>*")` — many attention/flash kernels live here.
+5. **Custom ops**: First use `Glob("vllm/**/*custom_op*")` to locate the actual custom op file
+   (commonly `vllm/_custom_ops.py` or `vllm/model_executor/custom_op.py`), then use Grep on
+   the found file(s) to check for the op name.
+6. **Model layers**: Use `Grep(pattern="<kernel_name>", path="vllm/model_executor/layers/")` for layer impls.
+7. **Tests**: Use `Glob("tests/kernels/*<kernel_name>*")` to find test files.
+8. **Benchmarks**: Use `Glob("benchmarks/kernels/*<kernel_name>*")` to find benchmark files.
+
+Also search for common aliases and naming variants:
+- Underscore vs concatenated: `rms_norm` vs `rmsnorm`, `silu_mul` vs `silu_and_mul`
+- CamelCase vs snake_case: `RMSNorm` vs `rms_norm`, `SiluAndMul` vs `silu_and_mul`
+- All-lowercase: `rmsnorm`, `layernorm`, `rotaryembedding`
+- **Partial name components**: for compound names like `silu_and_mul`, also search for `silu`
+  and `mul` individually — the kernel may live inside a file with a different name (e.g.,
+  `activation.py` contains `silu_and_mul`).
+
+### If the operator already exists
+
+Present the findings to the user and ask them to choose one of the following. Stop and wait
+for the user to respond before continuing:
+
+> The operator `<kernel_name>` already exists in the codebase:
+> - Implementation: `<file path>`
+> - Tests: `<file path>`
+> - Benchmarks: `<file path>`
+>
+> Please choose how to proceed:
+>
+> **A — Skip generation**: The operator already exists; do nothing.
+>
+> **B — Replace existing**: Overwrite the current implementation with MCP-generated code.
+>
+> **C — Create a custom variant (side-by-side)**: Generate as `<kernel_name>_v2` alongside
+> the original, without overriding the existing dispatch.
+
+Only proceed to Step 3 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 3.
+
+## Step 3: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials. This improves
+generation quality significantly.
+
+1. **Read similar operator code** from the codebase:
+   - Activation op → read `csrc/activation_kernels.cu` or `vllm/model_executor/layers/activation.py`
+   - Norm op → read `csrc/layernorm_kernels.cu` or `vllm/model_executor/layers/layernorm.py`
+   - Attention op → read files under `csrc/attention/` or `vllm/attention/`
+   - Quantization op → read files under `csrc/quantization/`
+   - MoE op → read files under `csrc/moe/` or `vllm/model_executor/layers/fused_moe/`
+
+2. **Read the test pattern** from the matching test file to understand shapes, dtypes, assertions.
+
+3. **Read the benchmark pattern** from the matching benchmark file to understand timing methodology.
+
+4. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+   **If reference files cannot be found or the Read tool fails**, do not stop. Proceed with
+   general algorithm hints based on your knowledge of the operator type instead. An empty or
+   minimal `flagos_wiki` is acceptable — it is better to continue than to block the workflow.
+
+5. Collect all findings into the `flagos_wiki` parameter as a `List[str]`. Rules:
+   - Each string should be a concise reference snippet, **under 200 characters** (not tokens).
+   - **Maximum 10 items** — avoid token explosion.
+   - **Prefer algorithm insights over file path descriptions** — the MCP generator benefits
+     more from understanding *how* an algorithm works than *where* a file lives.
+   - Avoid redundant items — do not repeat the same concept in different words (e.g., "block
+     reduction", "shared memory reduction", "warp reduction" are all the same idea).
+   - **Always include a kernel pattern hint** as the first item — this helps the MCP choose
+     the right code structure. The first item **MUST** start with the literal prefix
+     `"Kernel pattern: "` followed by one of: `elementwise`, `row-wise`, `reduction`,
+     `matmul-like`, `fused-multi-op`. Example: `"Kernel pattern: row-wise reduction over hidden_size"`.
+     Do not use alternative prefixes like `"Pattern:"` or `"Type:"` — the MCP parser expects
+     exactly `"Kernel pattern: "`.
+   - **Always include a memory layout hint**: `"Input tensors are contiguous row-major layout"`
+     — this reduces Triton miscompile risk for strided inputs.
+
+```python
+flagos_wiki = [
+    # GOOD: algorithm insights
+    "Layernorm uses Welford online algorithm for numerically stable variance computation",
+    "Block reduction via shared memory with warp-level shuffle for final reduction step",
+    "Vectorized loads using float4 for memory bandwidth optimization",
+    "RMSNorm computes 1/sqrt(mean(x^2) + eps) * x, no mean subtraction unlike LayerNorm",
+    # OK: structural hints when relevant
+    "Test parametrizes over NUM_TOKENS=[1,17,86,1234,3045] and HIDDEN_SIZES=[16,48,128,1562,4096]",
+    "Benchmark uses triton.testing.do_bench_cudagraph with quantiles=[0.5, 0.2, 0.8]",
+    # BAD (avoid): bare file paths with no insight
+    # "File: csrc/layernorm_kernels.cu"
+]
+```
+
+## Step 4: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+
+```
+kernel_name:  "<kernel_name>"
+func_desc:    "<description of what the operator does>"
+func_type:    "<activation|norm|attention|quantization|moe|sampling|other>"
+arg_names:    [<list of argument names>]
+arg_type:     [<list of argument types>]
+arg_descs:    [<list of argument descriptions>]
+output_arg_desc: "<description of the output>"
+flagos_wiki:     [<list of reference strings from Step 3>]
+```
+
+The MCP returns code blocks which may include:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+**If `torch_code` is missing from the MCP response**, construct a `ref_impl` yourself using
+standard PyTorch operations based on `func_desc`. For example, for `rms_norm`:
+```python
+def ref_impl(x, weight, eps=1e-6):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * weight
+```
+This is needed so that accuracy tests have a reference to compare against.
+
+## Step 4.5: MCP Report Review
+
+If the MCP response includes test results (accuracy test reports, benchmark/speedup reports),
+present them to the user **in full** before proceeding to local code adaptation:
+
+```
+=== MCP Generation Test Report ===
+
+Accuracy Test Results:
+<paste the COMPLETE accuracy test output from the MCP response — do not summarize or truncate>
+
+Performance Benchmark Results:
+<paste the COMPLETE benchmark/speedup output from the MCP response — do not summarize or truncate>
+```
+
+Then ask the user:
+
+> The MCP service has returned the above test reports from its generation environment.
+> Would you like to:
+>
+> **A — Skip local testing**: Trust the MCP reports and proceed directly to code placement
+> and summary. No local tests will be run.
+>
+> **B — Run local tests**: Run accuracy and performance tests on your local machine as well
+> to verify the results in your specific environment.
+
+Wait for the user's choice before proceeding:
+- If **A (skip local testing)**: After placing code in Step 5, skip Steps 6 and 7 (local
+  accuracy tests and benchmarks) and proceed directly to Step 8 (Summary). Use the MCP
+  report numbers for the summary.
+- If **B (run local tests)**: Proceed normally through Steps 5 → 6 → 7 → 8. Before
+  running local tests, perform the **Chip Compatibility Check** described in Step 5.5.
+
+**If the MCP response does NOT include test reports** (only code blocks), proceed normally
+to Step 5 — local testing will be required.
+
+## Step 5: Adapt and Place Code into the vLLM Project
+
+This is the most critical step. The generated code must be transformed to match vLLM conventions.
+The exact placement depends on the operator type and the user's choice in Step 2.
+
+---
+
+### Path 1: New operator / Replace existing (Option B or new op)
+
+#### 5a. Determine the Correct Location
+
+Based on operator type, place the code in the appropriate location:
+
+| Operator Type | Triton Kernel Location | Layer Wrapper Location | CUDA Alternative |
+|---|---|---|---|
+| Activation | `vllm/kernels/` or inline in layer | `vllm/model_executor/layers/activation.py` | `csrc/activation_kernels.cu` |
+| Normalization | `vllm/kernels/` or inline in layer | `vllm/model_executor/layers/layernorm.py` | `csrc/layernorm_kernels.cu` |
+| Attention | `vllm/attention/backends/` | `vllm/attention/layer.py` | `csrc/attention/` |
+| Quantization | `vllm/kernels/` | `vllm/model_executor/layers/quantization/` | `csrc/quantization/` |
+| MoE | `vllm/kernels/` | `vllm/model_executor/layers/fused_moe/` | `csrc/moe/` |
+| Position Encoding | `vllm/kernels/` | `vllm/model_executor/layers/rotary_embedding.py` | `csrc/pos_encoding_kernels.cu` |
+| Cache | `vllm/kernels/` | N/A | `csrc/cache_kernels.cu` |
+| Sampling | `vllm/kernels/` | `vllm/model_executor/layers/sampler.py` | `csrc/sampler.cu` |
+| Other | `vllm/kernels/<kernel_name>.py` | As needed | As needed |
+
+#### 5b. Transform the Triton Kernel Code
+
+Adapt the MCP-generated Triton code to follow vLLM conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8),
+    ],
+    # Choose autotune key based on kernel pattern:
+    #   elementwise → key=["n_elements"]
+    #   row-wise (layernorm, softmax) → key=["hidden_size"] or ["n_cols"]
+    # IMPORTANT: the key MUST match an existing non-pointer, non-constexpr
+    # kernel argument name. If the key does not exist in the kernel signature,
+    # Triton will raise a KeyError at compile time.
+    key=["n_elements"],  # ← replace with the actual problem-size arg name
+)
+@triton.jit
+def _<kernel_name>_kernel(
+    # pointer args
+    input_ptr,
+    output_ptr,
+    # dimensions
+    n_elements,
+    # meta parameters
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(input_ptr + offsets, mask=mask)
+    # kernel logic here
+    output = x  # placeholder
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def <kernel_name>(x: torch.Tensor) -> torch.Tensor:
+    """Python wrapper for the Triton kernel."""
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    output = torch.empty_like(x)
+    n_elements = x.numel()
+
+    def grid(meta):
+        return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _<kernel_name>_kernel[grid](
+        x, output, n_elements,
+    )
+    return output
+```
+
+**Important**: The example above is an **elementwise** kernel pattern. For **row-wise** kernels
+(layernorm, softmax, rmsnorm), the grid and indexing are different:
+
+```python
+def <kernel_name>(x: torch.Tensor, ...) -> torch.Tensor:
+    assert x.is_cuda and x.is_contiguous()
+    output = torch.empty_like(x)
+    num_rows, hidden_size = x.shape
+
+    # Row-wise: one program per row, each processes hidden_size elements
+    grid = (num_rows,)
+
+    _<kernel_name>_kernel[grid](
+        x, output, hidden_size,
+        # BLOCK_SIZE is autotuned via @triton.autotune
+    )
+    return output
+```
+
+**Choose the correct pattern based on kernel type:**
+- `activation` (elementwise): `grid = (triton.cdiv(n_elements, BLOCK_SIZE),)` — one program per block of elements
+- `norm` / `softmax` (row-wise): `grid = (num_rows,)` — one program per row
+- `attention` / `moe`: typically custom 2D/3D grids — follow MCP output
+- Always include `SPDX-License-Identifier: Apache-2.0` and copyright header
+- Use `vllm.logger.init_logger(__name__)` for logging
+- Kernel function names start with `_` and end with `_kernel`
+- Public wrapper function has a clean Python signature; use `x` (not `input`) as the tensor
+  parameter name to match vLLM convention and avoid shadowing Python's built-in `input()`
+- Use `torch.empty_like` or explicit allocation for outputs
+- Use `triton.cdiv` for grid computation
+- Use `tl.constexpr` for meta parameters like `BLOCK_SIZE`
+- **Use `@triton.autotune`** with power-of-two block sizes (64, 128, 256, 512) instead of
+  hardcoding a single BLOCK_SIZE. Avoid 1024 by default (register spill risk). Omit autotune
+  only for very simple kernels where a fixed block size is clearly optimal.
+- **Choose the correct autotune `key`**: use the main problem-size dimension that the launch grid
+  depends on. For elementwise kernels use `key=["n_elements"]`, for row-wise kernels (e.g.,
+  layernorm, softmax) use `key=["hidden_size"]` or `key=["n_cols"]`. The key must be a
+  non-pointer, non-constexpr parameter of the kernel.
+
+#### 5c. Register the Operator (if applicable)
+
+If the kernel needs to be callable via `vllm._custom_ops`:
+
+1. Use the Edit tool to add a Python wrapper function in `vllm/_custom_ops.py` (or the project's
+   actual custom op registration file if the path differs — verify with Glob first) that calls
+   the Triton kernel.
+2. If wrapping as a layer, use the Edit tool to add or modify the appropriate file under
+   `vllm/model_executor/layers/`.
+
+For Triton kernels that don't need custom op registration (standalone usage), just ensure
+the module is importable from `vllm.kernels.<kernel_name>`.
+
+#### 5d. Accuracy Test → `tests/kernels/test_<kernel_name>.py`
+
+Use the Write tool to create a test file following vLLM test conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+NUM_TOKENS = [1, 17, 128, 1024]
+HIDDEN_SIZES = [128, 512, 1024, 4096]
+SEEDS = [0]
+if not torch.cuda.is_available():
+    pytest.skip("CUDA not available", allow_module_level=True)
+
+CUDA_DEVICES = [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+
+# Tolerance per dtype — fp16/bf16 need looser tolerances to avoid flaky CI
+TOLERANCES = {
+    torch.float32: {"rtol": 1e-5, "atol": 1e-5},
+    torch.float16: {"rtol": 1e-2, "atol": 1e-2},
+    torch.bfloat16: {"rtol": 2e-2, "atol": 2e-2},
+}
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation.
+
+    This function uses pure PyTorch ops to compute the expected output.
+    It is used as ground truth for accuracy comparison.
+    """
+    # Use the torch_code from MCP as reference
+    ...
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_<kernel_name>(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    torch.random.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+
+    ref_out = ref_impl(x)
+
+    from vllm.kernels.<kernel_name> import <kernel_name> as kernel_fn
+    act_out = kernel_fn(x)
+
+    tol = TOLERANCES[dtype]
+    torch.testing.assert_close(act_out, ref_out, rtol=tol["rtol"], atol=tol["atol"])
+```
+
+Key conventions:
+- Always include the SPDX license header
+- Use `@torch.inference_mode()` decorator
+- Parametrize with `DTYPES`, `NUM_TOKENS`, `HIDDEN_SIZES`, `SEEDS`, `CUDA_DEVICES`
+- Use `torch.testing.assert_close` for comparison
+- **Use per-dtype tolerances**: fp32 can use 1e-5, but fp16/bf16 need 1e-2 to avoid false failures
+- Provide `ref_impl` using **pure PyTorch ops** (from MCP's `torch_code`) — not `torch.<op>` which
+  may not exist for custom fused kernels
+- Use `torch.random.manual_seed` for reproducibility; guard `torch.cuda.manual_seed` with
+  `if torch.cuda.is_available()` to avoid crash on CPU-only environments
+
+#### 5e. Performance Benchmark → `benchmarks/kernels/benchmark_<kernel_name>.py`
+
+Use the Write tool to create a benchmark file following vLLM benchmark conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import itertools
+
+import torch
+
+if not torch.cuda.is_available():
+    raise RuntimeError("CUDA is required to run this benchmark")
+
+import triton
+import triton.testing
+
+from vllm.utils.torch_utils import set_random_seed
+
+batch_size_range = [1, 16]
+seq_len_range = [1, 64, 1024]
+hidden_size_range = [1024, 4096]
+# 2 * 3 * 2 = 12 configs — keeps benchmark under 2 minutes
+configs = list(itertools.product(batch_size_range, seq_len_range, hidden_size_range))
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation (same as in the test file).
+
+    Used as the baseline for performance comparison.
+    """
+    # Paste the same ref_impl from the test file
+    ...
+
+
+def benchmark_<kernel_name>(
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    provider: str,
+    dtype: torch.dtype,
+):
+    device = torch.device("cuda")
+    num_tokens = batch_size * seq_len
+    set_random_seed(42)
+
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device).contiguous()
+
+    from vllm.kernels.<kernel_name> import <kernel_name> as kernel_fn
+
+    # Warmup — compile Triton kernel and stabilize GPU clocks before benchmarking
+    for _ in range(5):
+        kernel_fn(x)
+    torch.cuda.synchronize()
+
+    if provider == "triton":
+        fn = lambda: kernel_fn(x)
+    elif provider == "torch":
+        fn = lambda: ref_impl(x)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+        fn, quantiles=[0.5, 0.2, 0.8]
+    )
+    return ms, min_ms, max_ms
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "seq_len", "hidden_size"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["triton", "torch"],
+        line_names=["Triton Kernel", "PyTorch Reference"],
+        styles=[("blue", "-"), ("green", "-")],
+        ylabel="Time (ms)",
+        plot_name="<kernel_name>-benchmark",
+        # float16 is the default because Triton kernels are typically optimized for fp16 inference
+        args={"dtype": torch.float16},
+    )
+)
+def bench_<kernel_name>(batch_size, seq_len, hidden_size, provider, dtype):
+    return benchmark_<kernel_name>(batch_size, seq_len, hidden_size, provider, dtype)
+
+
+if __name__ == "__main__":
+    bench_<kernel_name>.run(print_data=True)
+```
+
+Key conventions:
+- Use `import triton; import triton.testing` directly (not `vllm.triton_utils`) for benchmarks,
+  as `vllm.triton_utils` may not export `triton.testing` in all versions
+- Use `triton.testing.do_bench_cudagraph` for accurate GPU timing
+- Use `triton.testing.perf_report` and `triton.testing.Benchmark` for structured output
+- **Always use `ref_impl` for the torch baseline**, never `torch.<op>` — many custom/fused
+  kernels have no single torch equivalent
+- Parametrize across batch sizes, sequence lengths, and hidden sizes
+- Use `set_random_seed` for reproducibility
+
+---
+
+### Path 2: Custom variant side-by-side (Option C)
+
+#### 5a. Operator Implementation → `vllm/kernels/<kernel_name>_v2.py`
+
+Use the Write tool to create the file. Use the **raw Triton pointer-based style** for the kernel.
+Keep the MCP-generated Triton code mostly as-is but ensure it:
+- Has the SPDX license header
+- Is self-contained (minimal vLLM imports)
+- Has proper `@triton.jit` kernel with pointer args, mask, and autotuned BLOCK_SIZE
+- Exports a clean Python wrapper function named `<kernel_name>_v2`
+
+#### 5b. Registration (limited)
+
+Do **NOT** register the variant in `vllm/_custom_ops.py` — it must NOT override the existing
+operator. The variant should be importable directly from `vllm.kernels.<kernel_name>_v2`.
+
+#### 5c. Standalone Test → `tests/kernels/test_<kernel_name>_v2.py`
+
+Use the Write tool to create a self-contained test file:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.kernels.<kernel_name>_v2 import <kernel_name>_v2 as kernel_fn
+
+
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+SHAPES = [(1, 128), (16, 512), (128, 1024), (1024, 4096)]
+SEEDS = [0]
+
+TOLERANCES = {
+    torch.float32: {"rtol": 1e-5, "atol": 1e-5},
+    torch.float16: {"rtol": 1e-2, "atol": 1e-2},
+    torch.bfloat16: {"rtol": 2e-2, "atol": 2e-2},
+}
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation."""
+    ...
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_<kernel_name>_v2_accuracy(shape, dtype, seed):
+    torch.random.manual_seed(seed)
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_out = ref_impl(x)
+    act_out = kernel_fn(x)
+    tol = TOLERANCES[dtype]
+    torch.testing.assert_close(act_out, ref_out, rtol=tol["rtol"], atol=tol["atol"])
+```
+
+#### 5d. Standalone Benchmark → `benchmarks/kernels/benchmark_<kernel_name>_v2.py`
+
+Use the Write tool to create a self-contained benchmark file following the same pattern as
+Path 1 Section 5e, but importing from `vllm.kernels.<kernel_name>_v2` and using `ref_impl`
+as the torch baseline.
+
+---
+
+## Step 6: Run Accuracy Tests
+
+### Step 5.5: Chip Compatibility Check (before local testing)
+
+Before running any local tests, verify that the local hardware matches the target device.
+vLLM operators typically target NVIDIA GPUs, but verify this explicitly:
+
+```bash
+python - <<'PY'
+import subprocess
+try:
+    import torch
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            print(f"nvidia: {torch.cuda.get_device_name(i)}")
+    else:
+        print("No CUDA device available")
+except Exception:
+    print("torch not available")
+try:
+    r = subprocess.run(["npu-smi", "info"], capture_output=True, text=True, timeout=5)
+    if r.returncode == 0 and "NPU" in r.stdout:
+        print("huawei: Ascend NPU detected")
+except Exception:
+    pass
+PY
+```
+
+**If the detected hardware does NOT match the operator's target device** (e.g., operator
+targets `huawei` but local machine has NVIDIA GPU, or vice versa), warn the user:
+
+```
+⚠️ Hardware mismatch detected:
+  - Operator target device: <target_device>
+  - Local hardware: <detected_hardware>
+
+Running tests for a <target_device> operator on <detected_hardware> hardware will likely
+fail or produce incorrect results. Please choose:
+
+  A — Skip local testing: Do not run local tests; rely on MCP test reports (if available).
+  B — Proceed anyway: Run local tests despite the mismatch (results may be unreliable).
+```
+
+If the user chooses A, skip Steps 6 and 7 and proceed to Step 8 (Summary).
+If the user chooses B, proceed with local tests but note the mismatch in the final report.
+
+---
+
+Use the Bash tool to run the accuracy tests for the newly added operator.
+
+First, verify the working directory is the vLLM repo root:
+```bash
+pwd
+```
+If the output is NOT the vLLM repo root (should contain `vllm/`, `csrc/`, `tests/`), stop
+and ask the user for the correct path.
+
+Then run with `PYTHONPATH=.` to ensure vllm is importable even if not pip-installed.
+
+**First, do a quick smoke test** to catch Triton compilation errors before running the full
+pytest suite (which produces messy output on compilation failures):
+
+```bash
+PYTHONPATH=. python -c "
+from vllm.kernels.<kernel_name> import <kernel_name> as fn
+import torch
+x = torch.randn(4, 128, dtype=torch.float16, device='cuda')
+# If kernel requires extra arguments (e.g. weight, bias, eps for norm kernels),
+# create matching dummy tensors:
+#   weight = torch.ones(128, dtype=torch.float16, device='cuda')
+#   out = fn(x, weight, eps=1e-6)
+out = fn(x)
+print('Smoke test passed, output shape:', out.shape)
+"
+```
+
+If this fails with `triton.compiler.CompilationError` or `ImportError`, fix the kernel code
+first — do not proceed to pytest. **Adapt the smoke test arguments to match the kernel's
+actual signature** — if the kernel requires `weight`, `bias`, `eps`, or other parameters,
+create appropriate dummy tensors or scalar values. Use `inspect.signature` to infer missing
+arguments (e.g., `weight`, `bias`, `eps` for `layer_norm`) before constructing the smoke test.
+
+**If smoke test passes, run the full test suite:**
+
+**For Path 1 (new / replace):**
+```bash
+PYTHONPATH=. python -m pytest tests/kernels/test_<kernel_name>.py -v
+```
+
+**For Path 2 (custom variant):**
+```bash
+PYTHONPATH=. python -m pytest tests/kernels/test_<kernel_name>_v2.py -v
+```
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 6a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Read the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Re-run the tests using the Bash tool.
+4. If the test **passes** → proceed to Step 7.
+5. If the test **still fails** → proceed to Step 6b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 6a entirely** — go directly
+to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 6b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+but add the error information to `flagos_wiki` as additional hints:
+```python
+flagos_wiki = [
+    # ... original flagos_wiki items from Step 3 ...
+    "Previous generation failed accuracy test: <brief error description>",
+    "Error was: <key line from traceback, e.g. 'AssertionError: values differ at index 42'>",
+    "Fix hint: <your analysis, e.g. 'epsilon not applied before rsqrt'>"
+]
+```
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6c.
+
+**Step 6c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback. This endpoint can fix
+memory access patterns, index calculations, and numerical issues.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6d.
+
+**Step 6d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+## Step 7: Run Performance Benchmark
+
+Use the Bash tool to run the benchmark with `PYTHONPATH=.`:
+
+**For Path 1 (new / replace):**
+```bash
+PYTHONPATH=. python benchmarks/kernels/benchmark_<kernel_name>.py
+```
+
+**For Path 2 (custom variant):**
+```bash
+PYTHONPATH=. python benchmarks/kernels/benchmark_<kernel_name>_v2.py
+```
+
+Report the speedup results to the user.
+
+## Step 8: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Generation Mode: New / Replace Existing / Custom Variant (v2)
+
+File Changes:
+  - [New/Modified] vllm/kernels/<kernel_name>.py          (Triton kernel)
+  - [Modified] vllm/_custom_ops.py                          (op registration, if applicable)
+  - [Modified] vllm/model_executor/layers/<layer_file>.py   (layer wrapper, if applicable)
+  - [New/Modified] tests/kernels/test_<kernel_name>.py     (accuracy test)
+  - [New/Modified] benchmarks/kernels/benchmark_<kernel_name>.py (benchmark)
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (batch_size=<B>, seq_len=<S>, hidden_size=<H>)
+  Worst Speedup: <X.XX>x (batch_size=<B>, seq_len=<S>, hidden_size=<H>)
+  (If benchmark was not run or failed, write "Incomplete" and explain why)
+
+MCP Iterations: <1, 2, or 3> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels (e.g. fused SwiGLU, fused GeLU+bias)"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern">
+
+Issues and Fixes: (if any)
+```
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user:
+  ```
+  ⚠️ The generated Triton kernel is slower than the PyTorch reference implementation.
+  This is typically caused by suboptimal memory access patterns or improper block size configuration.
+  Would you like to use /kernelgen_optimizer to optimize this kernel's performance?
+  ```
+
+- **If average speedup is 0.5x ~ 1.2x**, ask the user:
+  ```
+  Current speedup is low (<X.XX>x), there may be room for optimization.
+  Would you like to use /kernelgen_optimizer to try improving performance?
+  ```
+
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+**How to extract the numbers:**
+- **Pass/fail counts**: Parse pytest output for the line matching `X passed` or `X passed, Y failed`.
+  Use regex pattern `(\d+) passed` and `(\d+) failed` to extract.
+- **Speedup**: The benchmark outputs a table with columns for each provider. For each config row:
+  1. Find the `Triton Kernel` time (ms) and `PyTorch Reference` time (ms)
+  2. Calculate `speedup = torch_time / triton_time`
+  3. Compute min, max, and average across all config rows
+  - If the output format is not a table, look for lines containing `provider=triton` and
+    `provider=torch` with time values, and compute the ratio.
+  - Use these regex patterns to extract timing values:
+    - `(\d+(?:\.\d+)?)\s*(us|ms|s)` — number with unit
+    - `(?i)mean:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — mean timing (pytest-benchmark format)
+    - `(?i)avg:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — average timing
+    - `(?i)median:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — median timing value
+    - `(?i)Triton.*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — Triton kernel time
+    - `(?i)(torch|pytorch).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch reference time
+  - **Do not just copy the raw table** — always compute and report the actual speedup ratios.
+
+## Step 9: Post-Completion Actions
+
+After the summary is presented (whether based on MCP reports or local test results), perform
+the following two checks.
+
+### 9a. Chat Tool Notification
+
+If the user's task was received via a chat tool (e.g., Feishu/飞书, Discord, Slack, Teams,
+DingTalk/钉钉, WeChat Work/企业微信, Telegram, or any similar messaging platform), or if
+the user mentions sending results to a client or team, ask:
+
+> The operator generation is complete. Would you like me to prepare a message to send the
+> generated files or summary to your client/team via **<chat_tool_name>**?
+
+If the user confirms:
+1. Prepare a concise summary message including: operator name, file paths, accuracy pass
+   rate, speedup metrics, and any issues.
+2. If the chat tool has a CLI or API integration available in the environment, use it to
+   send the message directly.
+3. If no CLI/API is available, format the message as copy-paste ready text for the user.
+4. If files need to be sent, list the exact file paths the user should attach.
+
+### 9b. Git Repository PR Submission
+
+Check whether the current project is managed by a git-based hosting service:
+
+```bash
+git remote -v 2>/dev/null | head -5
+```
+
+Detect the hosting platform from the remote URL:
+- `github.com` → GitHub
+- `gitlab.com` (or self-hosted GitLab) → GitLab
+- `gitee.com` → Gitee
+- `bitbucket.org` → Bitbucket
+
+**If a git hosting platform is detected**, ask the user:
+
+> This project is hosted on **<platform>**. Would you like me to automatically create a
+> Pull Request with the generated operator code?
+
+**If the user confirms**, follow the standard PR creation workflow:
+
+1. Create a new branch: `kernelgen/<kernel_name>`
+2. Stage all changed/new files related to this operator generation (never use `git add -A`)
+3. Create a commit with a descriptive message
+4. Push the branch to the remote with `-u` flag
+5. Create the PR using the platform's CLI tool:
+
+   **For GitHub** (`gh`):
+   ```bash
+   gh pr create --title "Add <kernel_name> operator via KernelGen" --body "$(cat <<'EOF'
+   ## Summary
+   Add `<kernel_name>` operator (<func_type>) generated via KernelGen MCP service.
+
+   ## Changes
+   - [New/Modified] `<kernel_file_path>` — Triton kernel implementation
+   - [New/Modified] `<test_file_path>` — Accuracy tests
+   - [New/Modified] `<benchmark_file_path>` — Performance benchmarks
+   - [Modified] `<registration_files>` — Operator registration (if applicable)
+
+   ## Test Results
+   ### Accuracy
+   - **Pass rate**: <N>/<total> (<percentage>%)
+   - **Failed cases**: <list or "None">
+
+   ### Performance
+   - **Avg speedup**: <X.XX>x vs PyTorch reference
+   - **Best**: <X.XX>x | **Worst**: <X.XX>x
+
+   ## Generation Details
+   - **MCP iterations**: <count>
+   - **Target device**: <device>
+   - **Operator type**: <func_type>
+
+   ---
+   Generated by KernelGen MCP skill
+
+   EOF
+   )"
+   ```
+
+   **For Gitee / GitLab**: Provide the PR/MR creation URL and prepared description.
+
+6. Return the PR URL to the user.
+
+**If PR creation fails**, report the error, provide the branch name, and suggest manual PR
+creation with the prepared description.
+
+**If the user declines**, do nothing — changes remain as local files.
+
+## Important Notes
+
+- **Never overwrite existing operators** without explicit user permission (Step 2 choice).
+- **Always ask the user before installing packages** — never run `pip install` without confirmation.
+- **Follow vLLM code style** exactly: SPDX headers, logging via `init_logger`, type hints.
+- **Use explicit tools for all file operations**: Read tool to read files, **Write tool to create
+  new files** (only when the file does not exist), **Edit tool to modify existing files** (never
+  use Write to overwrite an existing file — use Edit to apply targeted changes), Glob tool to
+  find files, Grep tool to search content, Bash tool to run commands.
+- **Use `@triton.autotune`** with multiple power-of-two BLOCK_SIZE configs (64/128/256/512)
+  instead of hardcoding a single value. Include 64 for small hidden sizes (e.g., 96, 192).
+  Avoid 1024 by default as it risks register spill on complex kernels — only add it if the
+  kernel is very simple (e.g., elementwise with no shared state).
+- **Use per-dtype tolerances** in tests: fp32 → rtol/atol=1e-5, fp16 → 1e-2, bf16 → 2e-2.
+  For complex kernels (layernorm, softmax, attention) consider even looser bf16 tolerances (3e-2)
+  if CI is flaky.
+- **Always use `ref_impl` for benchmarks**, not `torch.<op>` — many custom/fused kernels have
+  no single torch equivalent function.
+- **Match the existing code patterns** when adding to existing files (e.g., `_custom_ops.py`, layer files).
+- If accuracy tests fail, try to fix the operator. If benchmark is slow, consider calling
+  `mcp__kernelgen-mcp__optimize_triton` to optimize the kernel.
+- When creating a custom variant, always make it clear that it does NOT override existing ops
+  to avoid conflicts.
+- **Always use `@torch.inference_mode()`** in tests for consistency with the codebase.
+- **Use `import triton; import triton.testing`** directly in benchmarks. Do not use
+  `vllm.triton_utils.triton` as it may not export `triton.testing` in all versions.
+- If the generated kernel is a CUDA kernel (not Triton), place it in `csrc/` and add bindings
+  in `csrc/torch_bindings.cpp` and `csrc/ops.h` — but prefer Triton when possible.
+- Check if the kernel needs to be registered in `vllm/model_executor/custom_op.py` if it's
+  an activation or layer-level op that should participate in the custom op dispatch system.
+- **Never modify unrelated files** in the repository. Do not reformat imports, fix lint, or
+  make stylistic changes to files that are not directly part of the operator being generated.
+  Keep the diff minimal and focused.

--- a/kernelgen-mcp/kernelgen-general.md
+++ b/kernelgen-mcp/kernelgen-general.md
@@ -1,0 +1,1199 @@
+
+# KernelGen Skill — Generate GPU Operators via MCP (General Purpose)
+
+You are an expert at generating GPU kernel operators using the `kernelgen-mcp` MCP service and
+integrating them into **any** Python/Triton repository. Unlike the specialized FlagGems or vLLM
+skills, this skill dynamically discovers the target repository's structure and conventions before
+placing code.
+
+**Tool usage**: This skill relies on the following capabilities:
+- **Bash**: execute shell commands (python, pip, pytest, etc.)
+- **Read**: read files from the codebase
+- **Write / Edit**: create or modify files
+- **Grep**: search file contents
+- **Glob**: find files by pattern
+- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+
+> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., the MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then follow the instructions in Step 0b to complete the configuration and retry. Do not proceed with subsequent steps if MCP is not ready.
+
+## Execution Rules
+
+Follow these rules strictly to avoid getting lost in the multi-step workflow:
+
+1. **Follow the steps in order**: Step 0 → Step 1 → ... → Step 9. Never jump ahead.
+2. **Never skip Step 2** (repo structure discovery) — always analyze before generating.
+3. **Never skip Step 3** (operator existence check) — always verify before generating.
+4. **Do not generate or write any code before Step 5** (MCP call). Steps 0–4 are preparation only.
+5. **Always confirm with the user before destructive actions**: replacing files, installing packages,
+   overwriting operators.
+6. **Report progress to the user when entering each step**. Print a short status line like
+   `Entering Step 2 — Analyzing repository structure...` so the user knows the workflow is progressing.
+7. **Never fabricate repository files or paths**. If a required file cannot be found using the
+   Glob or Grep tools, report it to the user instead of guessing.
+8. **Minimize file reads during discovery and search.** Always use Grep or Glob to locate
+   targets first. Only Read a file when you have a specific reason (e.g., learning conventions
+   from a reference operator, checking registration format). Never speculatively read files
+   "just in case".
+9. **Never scan the entire repository.** In Step 3 and beyond, only search inside directories
+   discovered in Step 2. Never run Grep on `.` or the repo root — always scope searches to
+   the specific discovered source, test, or benchmark directories. Unscoped searches cause
+   token explosion and match vendored code, docs, and build artifacts.
+10. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
+    `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+    wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
+    relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 5,
+    STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
+    The MCP service produces optimized, tested code that manual writing cannot match.
+
+---
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Use the Bash tool to run a diagnostic that checks each package independently:
+
+```bash
+python - <<'PY'
+import importlib, sys
+
+def check(pkg, alias=None):
+    try:
+        m = importlib.import_module(pkg)
+        ver = getattr(m, "__version__", "installed")
+        print(f"{alias or pkg}: {ver}")
+        return True
+    except Exception:
+        print(f"{alias or pkg}: NOT installed")
+        return False
+
+check("torch")
+check("triton")
+
+try:
+    import torch
+    print(f"cuda_version: {torch.version.cuda}")
+    print(f"cuda_available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            print(f"  cuda:{i} {torch.cuda.get_device_name(i)}")
+except Exception:
+    pass
+
+check("pytest")
+check("numpy")
+PY
+```
+
+**If any import fails**, stop and ask the user before installing anything. Present the missing
+packages and let the user confirm:
+
+| Missing package | Suggested install command | Notes |
+|---|---|---|
+| `torch` | Ask the user | User MUST pick the correct CUDA variant. Never auto-install torch. |
+| `triton` | `pip install triton` | |
+| `pytest` | `pip install pytest` | |
+| `numpy` | `pip install numpy` | |
+
+**Important**: Never install `torch` without asking the user which CUDA version they need.
+
+If `torch` is installed but `torch.cuda.is_available() == False`, warn the user that GPU tests
+will fail and ask how to proceed.
+
+After the user confirms and packages are installed, re-run the diagnostic. Only proceed when
+torch and triton imports succeed.
+
+### 0b. Check MCP Availability
+
+Use the Read tool to check for MCP configuration. **Only check project-local paths** — do NOT
+attempt to read user home directory (`~/`) as Claude Code typically cannot access it:
+
+1. `.claude/settings.json` — look for `mcpServers` containing the key `"kernelgen-mcp"`
+2. `.mcp.json` — same check
+
+If found, check whether the exact key `"kernelgen-mcp"` exists under `mcpServers`.
+Do NOT use substring matching (e.g., matching `"kernelgen"` inside another key name).
+
+**If the MCP server is NOT found in either file**, ask the user:
+
+```
+kernelgen-mcp service was not detected in the project configuration.
+
+Possible scenarios:
+  A) Not yet configured — Please visit https://kernelgen.flagos.io/ to register and obtain a JWT Token,
+     then provide me with the URL and Token, and I will write them to .claude/settings.json.
+  B) Already configured globally — If you have already configured kernelgen-mcp in your global settings,
+     please let me know and I will skip this step and continue.
+
+The final configuration format is as follows (.claude/settings.json):
+{
+  "mcpServers": {
+    "kernelgen-mcp": {
+      "type": "sse",
+      "url": "<YOUR_URL>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Wait for the user to respond. Then:
+- If the user provides URL + JWT: use the Edit tool (or Write tool if the file doesn't exist)
+  to write the configuration, **merging** with any existing content (never overwrite other MCP
+  server entries or top-level keys). Tell the user to restart Claude Code.
+- If the user says MCP is configured globally: proceed to Step 1.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+---
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name in **snake_case** (e.g., `rms_norm`, `relu`, `softmax`)
+- `func_desc`: what the operator does
+- `func_type`: one of `unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`,
+  `attention`, `activation`, `quantization`, `moe`, `blas`, `sampling`, `other`.
+  **Auto-infer from the operator signature when possible:**
+  - If 1 tensor input, no dim arg → `unary_pointwise`
+  - If operator has >=2 tensor inputs → `binary_pointwise`
+  - If has a `dim` argument → `reduction`
+  - If name contains `norm`, `softmax`, `rmsnorm`, `layernorm`, `batchnorm` → `normalization`
+  - If name contains `relu`, `gelu`, `silu`, `swish`, `tanh`, `sigmoid` → `activation`
+  - If name is `mm`, `matmul`, `bmm`, `addmm` → `blas`
+  - If name contains `attention`, `flash`, `paged` → `attention`
+  - If name contains `quant`, `awq`, `gptq` → `quantization`
+  - If name contains `moe`, `expert` → `moe`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous.
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+
+**Normalize `kernel_name` to snake_case** before using it anywhere:
+- `RMSNorm` → `rms_norm`
+- `SiluAndMul` → `silu_and_mul`
+- `LayerNorm` → `layer_norm`
+
+Check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+| logarithm / ln | `log` |
+| exponential | `exp` |
+| hyperbolic_tangent | `tanh` |
+| square | `pow (exp=2)` |
+| square_root | `sqrt` |
+| cube | `pow (exp=3)` |
+| cube_root | `cbrt` |
+| inverse_sqrt | `rsqrt` |
+| reciprocal / inverse | `reciprocal` |
+| minimum | `min` |
+| maximum | `max` |
+| floor_divide | `floor_divide` |
+| modulo / mod | `remainder` |
+
+### Complexity Gate
+
+Before proceeding, check the `func_type`. If it is one of the following **complex** types,
+warn the user and ask for explicit confirmation before continuing:
+
+- `attention`
+- `moe`
+- `quantization`
+- `sampling`
+
+```
+Note: Operators of type <func_type> are relatively complex. KernelGen's auto-generation success rate is approximately 60%,
+and manual tuning may be required. Do you want to proceed with generation?
+```
+
+For simpler types (`unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`,
+`activation`, `blas`), proceed without warning — these have >90% success rate.
+
+### Argument Inference
+
+**If argument information is missing or the description is vague**:
+
+1. Use the Grep tool to search for the operator name **only inside directories discovered in
+   Step 2** (source dirs, test dirs, kernel dirs) to infer argument signatures from existing
+   code. **Never grep the repo root or unscoped paths** — this causes token explosion in
+   large repos.
+2. Present the inferred signature to the user for confirmation before proceeding.
+3. **Fallback**: If no matches are found, use a default signature based on `func_type`:
+
+   | func_type | Default args |
+   |---|---|
+   | `unary_pointwise`, `activation` | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+   | `binary_pointwise` | `arg_names: ["x", "y"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | `normalization` | `arg_names: ["x", "weight"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | `reduction` | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+   | `attention` | `arg_names: ["q", "k", "v"]`, `arg_type: ["torch.Tensor", "torch.Tensor", "torch.Tensor"]` |
+   | `blas` | `arg_names: ["a", "b"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | other | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+
+   Present the default to the user and ask them to confirm or refine. **Do not send defaults
+   directly to MCP without user confirmation** — a wrong signature causes schema errors.
+
+---
+
+## Step 2: Discover Repository Structure
+
+**This step is critical.** Unlike the FlagGems/vLLM-specific skills, we do NOT assume any fixed
+directory layout. Instead, we dynamically discover the project structure.
+
+### 2a. Identify the Project Type
+
+Use the Glob and Read tools to check for project identity:
+
+```
+Glob: pyproject.toml, setup.py, setup.cfg
+```
+
+Read `pyproject.toml` (or `setup.py` / `setup.cfg`) to determine:
+- **Project name** (e.g., `flag_gems`, `vllm`, `lmdeploy`, etc.)
+- **Source root** (e.g., `src/`, `.`, `lib/`)
+- **Package name** — the importable top-level module
+
+**Known-project shortcut**: If the project name matches a known specialized skill, inform
+the user and suggest switching:
+
+| Project name | Specialized skill | Suggestion |
+|---|---|---|
+| `flag_gems` / `FlagGems` | `/kernelgen_for_flaggems` | "Detected FlagGems repository. It is recommended to use the specialized skill `/kernelgen_for_flaggems` for a higher success rate. Would you like to switch?" |
+| `vllm` | `/kernelgen_for_vllm` | "Detected vLLM repository. It is recommended to use the specialized skill `/kernelgen_for_vllm` for a higher success rate. Would you like to switch?" |
+
+If the user agrees, stop and tell them to invoke the specialized skill. If the user declines
+or the project is not in the table, continue with the general skill.
+
+### 2b. Map Key Directories
+
+Use the Glob tool with **shallow patterns** to avoid token explosion in large repos. Do NOT
+use deep recursive `**` patterns that could match thousands of files.
+
+**Important**: If any single Glob returns more than 20 matches, **stop inspecting that
+pattern** — just record the directory prefix (e.g., `src/pkg/ops/`) and move on. Do NOT
+read or list all matched files; only note the directory structure.
+
+```
+Glob: src/*/ops/*.py          (source ops — one level under src/)
+Glob: src/*/kernels/*.py      (source kernels)
+Glob: */ops/*.py              (top-level package ops)
+Glob: */kernels/*.py          (top-level package kernels)
+Glob: tests/*.py              (top-level tests)
+Glob: tests/kernels/*.py      (kernel-specific tests)
+Glob: benchmark*/*.py         (benchmarks)
+Glob: benchmark*/kernels/*.py (kernel benchmarks)
+```
+
+If these shallow patterns return no results for a category, try ONE level deeper:
+```
+Glob: src/*/*/ops/*.py
+Glob: src/*/*/kernels/*.py
+```
+
+If **still** no operator directory is found, run a generic fallback scan:
+```
+Glob: src/*/*kernel*.py
+Glob: src/*/*op*.py
+```
+This catches non-standard directory names like `triton_kernels/`, `gpu_ops/`, `cuda_ops/`.
+
+**Stop expanding once you find matches.** Do not keep globbing deeper.
+
+**Early-stop rule**: Once you have discovered both an **operator source directory** and a
+**test directory**, stop all further glob exploration. Do not continue searching for additional
+directories — two anchors are sufficient to infer the rest of the layout.
+
+**Disambiguation rule**: If multiple operator directories are discovered (e.g., `src/foo/ops/`
+and `src/bar/ops/`), **prefer the one that belongs to the main package name** detected in
+Step 2a (`pyproject.toml`). If still ambiguous, ask the user which directory to use.
+
+Record the discovered layout in this table (fill in dynamically):
+
+| Purpose | Discovered Path |
+|---------|----------------|
+| **Operator source code** | _(e.g., `src/pkg/ops/`, `pkg/kernels/`, etc.)_ |
+| **Tests (accuracy)** | _(e.g., `tests/`, `tests/kernels/`, etc.)_ |
+| **Benchmarks** | _(e.g., `benchmark/`, `benchmarks/kernels/`, etc.)_ |
+| **Init/registry files** | _(e.g., `src/pkg/ops/__init__.py`, etc.)_ |
+| **Custom op registration** | _(e.g., `pkg/_custom_ops.py`, etc.)_ |
+
+### 2c. Study Existing Operators as Reference
+
+Find an existing operator implementation similar to the requested one and read it to learn:
+
+1. **Import style** — what modules are imported, decorator patterns
+2. **Kernel style** — raw Triton pointer-based, or higher-level wrappers like `pointwise_dynamic`
+3. **Function naming** — snake_case, prefix/suffix conventions (e.g., `_kernel`, `_forward`)
+4. **Wrapper pattern** — how the Python wrapper calls the Triton kernel
+5. **License headers** — whether files start with SPDX or other license headers
+6. **Logging** — which logging approach is used (e.g., `vllm.logger.init_logger`, stdlib `logging`)
+7. **Autotune usage** — whether the repo uses `@triton.autotune` and which BLOCK_SIZE configs.
+   If autotune is used, also note `num_warps` and `num_stages` values from existing configs —
+   these will be replicated for the new kernel's autotune configs in Step 6.
+
+Also read the matching test and benchmark files to learn:
+- **Test pattern**: parametrize style, shapes, dtypes, assertion utilities
+- **Benchmark pattern**: timing methodology, reporting format
+
+**Store all discovered conventions** — they will be applied in Step 6.
+
+---
+
+## Step 3: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase for existing implementations
+using the Glob and Grep tools.
+
+### 3a. Generate Search Variants
+
+From `kernel_name`, generate **all naming variants** to search:
+- snake_case: `layer_norm`
+- concatenated lowercase: `layernorm`
+- CamelCase: `LayerNorm`
+- Partial components (for compound names): only if `kernel_name` contains `_and_` or `_with_`,
+  split and search components **longer than 4 characters**. Example:
+  - `silu_and_mul` → search `silu` (5 chars, OK), skip `mul` (3 chars, too short)
+  - `add_relu` → do NOT split (no `_and_` / `_with_`), search as whole name only
+  Short fragments like `mul`, `add`, `div`, `neg` match too many unrelated symbols.
+
+### 3b. Search
+
+For **each** naming variant, search:
+1. **Source files**: Glob for `*<variant>*.py` in discovered source directories (shallow)
+2. **Function and class definitions**: Grep for these patterns in discovered source directories:
+   - `def <variant>` — direct function definition
+   - `<variant>_kernel` — kernel function naming convention
+   - `<variant>_forward` — forward function naming convention
+   - `<variant>_backward` — backward function naming convention
+   - `class <CamelCaseVariant>` — class-based operator (e.g., `class LayerNorm`,
+     `class SoftmaxKernel`, `class RMSNormOp`)
+   - `register_op("<variant>")` / `OP_REGISTRY["<variant>"]` / `aten_map["<variant>"]` —
+     dispatch-style registration where the implementation function name may differ from
+     the operator name
+   This catches operators that live inside files with different names (e.g., `softmax_kernel`
+   inside `normalization.py`, or `silu_and_mul` inside `activation.py`).
+3. **Init/registry**: Grep for `<variant>` in all `__init__.py` files and any custom op
+   registration files found in Step 2
+4. **Tests**: Grep for `<variant>` in discovered test directories
+5. **Benchmarks**: Grep for `<variant>` in discovered benchmark directories
+
+### If the operator already exists
+
+Present findings to the user and ask them to choose. **Stop and wait** for the user's explicit
+choice before continuing:
+
+> Detected that the `<kernel_name>` operator already exists in the repository:
+> - Implementation: `<file path>`
+> - Tests: `<file path>`
+> - Benchmarks: `<file path>`
+>
+> Please choose how to proceed:
+>
+> **A — Cancel generation**: Keep the existing operator unchanged.
+>
+> **B — Replace existing**: Replace the current implementation with a new version generated by KernelGen.
+>
+> **C — Add custom variant side-by-side**: Keep the existing operator and place the new version as `<kernel_name>_v2` alongside it, so both coexist.
+
+Only proceed to Step 4 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 4.
+
+---
+
+## Step 4: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials that improve
+generation quality:
+
+1. **Read similar operator code** from the codebase — pick the most similar existing operator
+   to the one being generated (same `func_type`).
+
+2. **Read the test pattern** from the matching test file to understand shapes, dtypes, assertions.
+
+3. **Read the benchmark pattern** from the matching benchmark file to understand timing methodology.
+
+4. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+   **If reference files cannot be found**, do not stop. Proceed with general algorithm hints
+   based on your knowledge of the operator type. An empty or minimal `flagos_wiki` is acceptable.
+
+5. Collect all findings into the `flagos_wiki` parameter as a `List[str]`. Rules:
+   - Each string should be a concise reference snippet, **under 200 characters**.
+   - **Maximum 10 items** — avoid token explosion.
+   - **Prefer algorithm insights over file path descriptions**.
+   - **Always include a kernel pattern hint** as the first item (e.g.,
+     `"Kernel pattern: elementwise"`, `"Kernel pattern: row-wise reduction over hidden_size"`).
+   - **Always include `"Use Triton for GPU parallelization"` as the second item** — this
+     anchors the generator toward Triton output and reduces fallback failures.
+   - **Always include a memory layout hint** (e.g.,
+     `"Input tensors are contiguous row-major layout"`).
+   - **Include a memory access pattern hint if inferable** from the `func_type` (e.g.,
+     `"Memory access: coalesced contiguous loads"` for pointwise/elementwise,
+     `"Memory access: row-wise strided reads over hidden_size"` for normalization/reduction).
+     This significantly improves generated kernel quality.
+   - Include relevant conventions discovered in Step 2 (e.g.,
+     `"Repo uses pointwise_dynamic wrapper for elementwise ops"`,
+     `"Repo uses @triton.autotune with BLOCK_SIZE configs [64,128,256,512]"`).
+
+---
+
+## Step 5: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+
+```
+kernel_name:     "<kernel_name>"
+func_desc:       "<description of what the operator does>"
+func_type:       "<func_type>"
+arg_names:       [<list of argument names>]
+arg_type:        [<list of argument types>]
+arg_descs:       [<list of argument descriptions>]
+output_arg_desc: "<description of the output>"
+flagos_wiki:        [<list of reference strings from Step 4>]
+```
+
+The MCP returns code blocks which may include:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+**If `torch_code` is missing**, construct a `ref_impl` yourself using standard PyTorch ops
+based on `func_desc`.
+
+### MCP Failure Retry Strategy
+
+If the MCP call fails, apply retries in this order:
+
+1. **First retry**: Remove `flagos_wiki` parameter and call again (handles `unexpected argument`
+   / `unknown field` / `invalid schema` errors).
+2. **Second retry**: Use minimal parameters only (`kernel_name`, `func_desc`, `func_type`,
+   `arg_names`, `arg_type`) — drop `arg_descs`, `output_arg_desc`, and `flagos_wiki`.
+3. **Third retry**: Change `func_type` to `"other"` and keep only minimal parameters. This
+   handles `func_type` mismatch errors where the MCP backend does not recognize the original
+   `func_type` value (e.g., `activation` vs `unary_pointwise`).
+4. **If still failing**: Stop and report the exact error to the user. Do NOT keep retrying.
+
+---
+
+## Step 5.5: MCP Report Review
+
+If the MCP response includes test results (accuracy test reports, benchmark/speedup reports),
+present them to the user **in full** before proceeding to local code adaptation:
+
+```
+=== MCP Generation Test Report ===
+
+Accuracy Test Results:
+<paste the COMPLETE accuracy test output from the MCP response — do not summarize or truncate>
+
+Performance Benchmark Results:
+<paste the COMPLETE benchmark/speedup output from the MCP response — do not summarize or truncate>
+```
+
+Then ask the user:
+
+> The MCP service has returned the above test reports from its generation environment.
+> Would you like to:
+>
+> **A — Skip local testing**: Trust the MCP reports and proceed directly to code placement
+> and summary. No local tests will be run.
+>
+> **B — Run local tests**: Run accuracy and performance tests on your local machine as well
+> to verify the results in your specific environment.
+
+Wait for the user's choice before proceeding:
+- If **A (skip local testing)**: After placing code in Step 6, skip Steps 7 and 8 (local
+  accuracy tests and benchmarks) and proceed directly to Step 9 (Summary). Use the MCP
+  report numbers for the summary.
+- If **B (run local tests)**: Proceed normally through Steps 6 → 7 → 8 → 9. Before
+  running local tests, perform the **Chip Compatibility Check** described in Step 6.5d.
+
+**If the MCP response does NOT include test reports** (only code blocks), proceed normally
+to Step 6 — local testing will be required.
+
+---
+
+## Step 6: Adapt and Place Code into the Repository
+
+This is the most critical step. The generated code must be **transformed to match the local
+repository's conventions** discovered in Step 2.
+
+### 6a. Transform the Kernel Code
+
+Apply the conventions discovered in Step 2c. **The decision to rewrite depends entirely on
+what the repo actually uses** — never assume:
+
+**Only rewrite to wrapper style if BOTH conditions are met**:
+1. The repo explicitly uses wrapper utilities (e.g., FlagGems `pointwise_dynamic`).
+2. The reference operator's kernel function signature receives **scalar elements** (not pointers).
+
+If either condition is unclear, **keep the MCP-generated raw Triton pointer-based code**.
+Misidentifying wrapper style produces completely broken kernels.
+
+When rewriting to wrapper style:
+- The `@triton.jit` kernel should receive **scalar elements** (not pointers).
+- **Remove ALL** `tl.load()`, `tl.store()`, pointer arithmetic, mask logic, and BLOCK_SIZE
+  parameters — the wrapper handles these automatically.
+- Only keep the pure math expression.
+
+**Otherwise, keep the MCP-generated raw Triton pointer-based code.** This is the safer default
+for most repositories. Apply these adaptations:
+- **Match the repo's autotune convention exactly**:
+  - If existing kernels use `@triton.autotune` → add it, using the same BLOCK_SIZE configs
+    found in existing kernels.
+  - If existing kernels do **NOT** use `@triton.autotune` (e.g., torchinductor, tinygrad, some
+    inference engines explicitly avoid it) → do **NOT** introduce it. Use a fixed BLOCK_SIZE
+    matching the repo's pattern instead.
+  - If no existing kernels are found for reference, use a default autotune set:
+  ```python
+  @triton.autotune(
+      configs=[
+          triton.Config({"BLOCK_SIZE": 64}, num_warps=4),
+          triton.Config({"BLOCK_SIZE": 128}, num_warps=4),
+          triton.Config({"BLOCK_SIZE": 256}, num_warps=8),
+          triton.Config({"BLOCK_SIZE": 512}, num_warps=8),
+      ],
+      key=["n_elements"],  # replace with actual problem-size arg name
+  )
+  ```
+- Ensure proper `tl.constexpr` for meta parameters.
+- Use `triton.cdiv` for grid computation.
+
+**Common adaptations for all repos:**
+- Add the repo's standard license header (if any, discovered in Step 2c).
+- Use the repo's logging approach (e.g., `vllm.logger.init_logger`, `logging.getLogger`).
+- Follow the repo's naming conventions for kernel functions (e.g., `_kernel` suffix, `_forward`
+  suffix).
+- Match import style exactly.
+
+### 6b. Determine File Placement
+
+Place files according to the layout discovered in Step 2b:
+
+| File | Location |
+|------|----------|
+| Kernel implementation | Discovered operator source directory + `<kernel_name>.py` |
+| Accuracy test | Discovered test directory + `test_<kernel_name>.py` (or append to existing test file if the repo groups tests by category) |
+| Performance benchmark | Discovered benchmark directory + `benchmark_<kernel_name>.py` (or append to existing benchmark file) |
+
+**Decision: separate file vs. append to existing?**
+- Use the Glob tool to check if the repo uses **one test file per operator** (e.g.,
+  `tests/test_relu.py`, `tests/test_softmax.py`) or **grouped test files** (e.g.,
+  `tests/test_unary_pointwise_ops.py`, `tests/test_reduction_ops.py`).
+- If grouped: use the Edit tool to append the new test to the appropriate existing file.
+- If per-operator: use the Write tool to create a new test file.
+- Apply the same logic for benchmarks.
+
+### 6c. Write the Kernel Implementation
+
+Use the Write tool (new file) or Edit tool (replacing existing) to create the operator file.
+
+The implementation should follow the exact pattern of similar operators in the repo. Include:
+- License header (if the repo uses one)
+- Imports matching repo style
+- Triton kernel function(s)
+- Python wrapper function(s)
+- Logging statements matching repo convention
+- In-place variants if applicable (verify pattern by reading an existing in-place op first)
+
+### 6d. Register the Operator (if applicable)
+
+If the repo has a registration mechanism, use the Edit tool to register the new operator.
+
+**First, discover the registration mechanism.** Not all repos use `__init__.py`. Search for:
+- `__init__.py` exports (most common)
+- Grep for `register_op`, `OP_REGISTRY`, `_dispatch_table`, `aten_map`, `_FULL_CONFIG` in
+  the discovered source directories — these are common registry patterns
+- `_custom_ops.py` or similar custom op registration files found in Step 2
+
+If a registration mechanism is found:
+1. **Read the registration file** first to understand the exact format.
+2. **Add the new entry in alphabetical order** — do not change existing entries.
+3. **Match the exact registration format** used by existing entries.
+
+If **no registration mechanism is found**, check one more thing before skipping:
+
+**Implicit import check**: If the operator source directory contains an `__init__.py` that
+imports other operators (e.g., `from .relu import *`, `from .softmax import softmax`), you
+MUST add a corresponding import line for the new operator. Otherwise the kernel file exists
+but the package cannot import it.
+
+```python
+# Example: src/pkg/ops/__init__.py already has:
+from .relu import relu
+from .softmax import softmax
+# → Add:
+from .<kernel_name> import <kernel_name>
+```
+
+If `__init__.py` does not exist or is empty, the kernel is standalone — skip registration.
+
+For **Option C (side-by-side variant)**: Do NOT register in the main dispatch mechanism. Only
+add to `__init__.py` for importability, not for aten/dispatch override.
+
+### 6e. Write the Accuracy Test
+
+Follow the test pattern discovered in Step 2c. Key conventions to match:
+- Parametrize decorators (shapes, dtypes, seeds, devices)
+- Reference implementation approach (pure PyTorch `ref_impl` vs `torch.<op>`)
+- Assertion method (`torch.testing.assert_close`, `gems_assert_close`, custom utils)
+- Per-dtype tolerances: fp32 → rtol/atol=1e-5, fp16 → 1e-2, bf16 → 2e-2
+- Test markers / decorators (`@pytest.mark.<kernel_name>`, `@torch.inference_mode()`, etc.)
+- Device handling (`flag_gems.device`, `"cuda"`, parametrized CUDA_DEVICES)
+- If the repo uses `to_reference()` or similar utilities, use them.
+
+If the repo registers pytest markers, add the new marker to the marker registration file
+(check `pytest.ini`, `pyproject.toml [tool.pytest.ini_options]`, or `setup.cfg`).
+
+### 6f. Write the Performance Benchmark
+
+Follow the benchmark pattern discovered in Step 2c. Key conventions to match:
+- Timing methodology (`triton.testing.do_bench_cudagraph`, `GenericBenchmark`, custom)
+- Reporting format (`triton.testing.perf_report`, print-based, etc.)
+- Configuration ranges (batch sizes, sequence lengths, hidden sizes)
+- Baseline comparison (always use `ref_impl` for the baseline, not `torch.<op>` which may
+  not exist for fused kernels)
+
+---
+
+## Step 6.5: Pre-test Validation
+
+Before running the full test suite, perform quick checks:
+
+### 6.5a. Lint / Format Check
+
+If the repo uses linting tools, run them on the changed files:
+
+```bash
+# Check which linter the repo uses
+# Look in pyproject.toml for [tool.ruff], [tool.black], [tool.isort], etc.
+```
+
+If found, run the linter on changed files to catch style issues early. If no linter is
+configured, skip this step.
+
+### 6.5b. Import Smoke Test
+
+Verify the new module can be imported:
+
+```bash
+python -c "from <module_path> import <kernel_name>; print('Import OK')"
+```
+
+### 6.5c. Triton Compile Smoke Test
+
+Run a minimal invocation to catch Triton compile errors early. **Build the smoke test call
+based on `arg_names` from Step 1** — do NOT hardcode a single-argument call.
+
+**Important**: Guard the device selection so the smoke test does not crash if CUDA is
+unavailable (even though Step 0 checked — the user may have chosen to proceed without GPU):
+
+```python
+import torch
+device = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+**If `device == "cpu"`**: Skip the Triton compile smoke test entirely. Triton kernels require
+CUDA and will crash with `RuntimeError` on CPU. Report to the user:
+```
+CUDA unavailable — skipping Triton compile test. The kernel will be compiled for the first time during the Step 7 accuracy tests.
+```
+Then proceed directly to Step 7.
+
+**If `device == "cuda"`**: construct the call based on `func_type` and `arg_names`.
+
+Then construct the call based on `func_type` and `arg_names`. **Use shapes inferred from the
+reference operator read in Step 2c.** If no reference shapes are available, use these fallbacks:
+
+```python
+# Fallback shapes by func_type:
+#   unary_pointwise / activation: (128,)
+#   binary_pointwise:             (128,)
+#   reduction:                    (32, 128)
+#   normalization:                (32, 128) + weight of shape (128,)
+#   attention:                    (1, 4, 8) for q/k/v
+#   blas:                         (32, 64) and (64, 32)
+
+# For unary ops (arg_names: ["x"]):
+x = torch.randn(128, device=device, dtype=torch.float16)
+out = kernel_fn(x)
+
+# For binary ops (arg_names: ["x", "y"]):
+x = torch.randn(128, device=device, dtype=torch.float16)
+y = torch.randn(128, device=device, dtype=torch.float16)
+out = kernel_fn(x, y)
+
+# For normalization ops (arg_names: ["x", "weight"]):
+x = torch.randn(32, 128, device=device, dtype=torch.float16)
+weight = torch.ones(128, device=device, dtype=torch.float16)
+out = kernel_fn(x, weight)
+
+# For attention ops (arg_names: ["q", "k", "v"]):
+q = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+k = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+v = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+out = kernel_fn(q, k, v)
+```
+
+**General rule**: create one small tensor for each entry in `arg_names`, matching the
+expected shapes for the `func_type`. Use `inspect.signature` to infer any missing arguments
+(e.g., `weight`, `bias`, `eps` for `layer_norm`) before constructing the smoke test, so that
+all required parameters are covered. If the smoke test fails, read the error and fix the
+kernel before proceeding.
+
+### 6.5d. Chip Compatibility Check (before local testing)
+
+Before running any local tests, verify that the local hardware matches the target device
+specified for the operator. Use the Bash tool to detect local hardware:
+
+```bash
+python - <<'PY'
+import subprocess, sys
+
+def detect():
+    chips = []
+    # NVIDIA GPU
+    try:
+        import torch
+        if torch.cuda.is_available():
+            for i in range(torch.cuda.device_count()):
+                chips.append(("nvidia", torch.cuda.get_device_name(i)))
+    except Exception:
+        pass
+    # Huawei Ascend NPU
+    try:
+        r = subprocess.run(["npu-smi", "info"], capture_output=True, text=True, timeout=5)
+        if r.returncode == 0 and "NPU" in r.stdout:
+            chips.append(("huawei", "Ascend NPU"))
+    except Exception:
+        pass
+    # AMD / Hygon DCU
+    try:
+        r = subprocess.run(["rocm-smi"], capture_output=True, text=True, timeout=5)
+        if r.returncode == 0:
+            chips.append(("haiguang" if "hygon" in r.stdout.lower() else "amd", "ROCm device"))
+    except Exception:
+        pass
+    if not chips:
+        chips.append(("unknown", "No accelerator detected"))
+    for kind, name in chips:
+        print(f"  {kind}: {name}")
+    return chips
+
+print("Local hardware:")
+detect()
+PY
+```
+
+Compare the detected hardware with the operator's `target_device` (determined in Step 1 or
+inferred from user context — default is `nvidia`):
+
+| Target Device | Required Local Hardware |
+|---|---|
+| `nvidia` | NVIDIA GPU (detected via `torch.cuda`) |
+| `huawei` | Huawei Ascend NPU (detected via `npu-smi`) |
+| `haiguang` | Hygon DCU (detected via `rocm-smi` with Hygon identifier) |
+| `moore` | Moore Threads GPU |
+| `tianshu` | Tianshu GPU |
+
+**If the local hardware does NOT match the target device**, warn the user:
+
+```
+⚠️ Hardware mismatch detected:
+  - Operator target device: <target_device>
+  - Local hardware: <detected_hardware>
+
+Running tests for a <target_device> operator on <detected_hardware> hardware will likely
+fail or produce incorrect results. Please choose:
+
+  A — Skip local testing: Do not run local tests; rely on MCP test reports (if available).
+  B — Proceed anyway: Run local tests despite the mismatch (results may be unreliable).
+```
+
+If the user chooses A, skip Steps 7 and 8 and proceed to Step 9 (Summary).
+If the user chooses B, proceed with local tests but note the mismatch in the final report.
+
+**If the hardware matches**, proceed normally.
+
+---
+
+## Step 7: Run Accuracy Tests
+
+Use the Bash tool to run accuracy tests.
+
+First, determine the correct invocation based on repo structure. **Prefer `pytest` over
+`python -m pytest`** because many repos depend on `conftest.py` discovery which works more
+reliably with direct `pytest` invocation:
+
+1. **Primary**: `pytest <test_path> -q` (use `-q` to minimize output and avoid token explosion;
+   only switch to `-v` if a test fails and you need detailed traceback)
+2. **Fallback** (if `pytest` command not found): `python -m pytest <test_path> -q`
+3. **If not pip-installed**: prepend `PYTHONPATH=.` to either command
+
+For grouped test files, use `-m <kernel_name>` or `-k <kernel_name>` to select only the
+new operator's tests.
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 7a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Read the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Re-run the tests.
+4. If the test **passes** → proceed to Step 8.
+5. If the test **still fails** → proceed to Step 7b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 7a entirely** — go directly
+to Step 7b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 7b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 5**,
+but add the error information to `flagos_wiki` as additional hints:
+```python
+flagos_wiki = [
+    # ... original flagos_wiki items from Step 4 ...
+    "Previous generation failed accuracy test: <brief error description>",
+    "Error was: <key line from traceback>",
+    "Fix hint: <your analysis>"
+]
+```
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 8.
+- If tests **still fail** → proceed to Step 7c.
+
+**Step 7c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback. This endpoint can fix
+memory access patterns, index calculations, and numerical issues.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 8.
+- If tests **still fail** → proceed to Step 7d.
+
+**Step 7d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+---
+
+## Step 8: Run Performance Benchmark
+
+Use the Bash tool to run the benchmark.
+
+Determine invocation based on repo structure:
+- Standalone benchmark file: `python <benchmark_path>`
+- pytest-based benchmark: `python -m pytest <benchmark_path> -q -k "perf"`
+
+**Timeout**: Run the benchmark with a **120-second timeout**. If it exceeds this without
+completing, interrupt the process and report partial results to the user:
+```
+Benchmark exceeded 120 seconds without completing, interrupted. Partial output below:
+<partial output>
+For a full benchmark, please run manually: python <benchmark_path>
+```
+Some benchmarks (e.g., large sweep over sequence lengths / hidden sizes) can run for tens of
+minutes — the user should run these manually outside the skill.
+
+### Speedup Extraction
+
+Try to extract speedup metrics from the output:
+1. Look for explicit speedup with `x` suffix: `(\d+\.?\d*)x`
+2. Look for explicit `speedup` labels: `speedup.*?(\d+\.?\d*)`
+3. Look for paired timing values (triton vs torch): extract both and compute
+   `speedup = torch_latency / kernel_latency`
+4. Look for timing with units: `(\d+\.?\d*)\s*(us|ms|s)`
+
+**Fallback**: If latency values cannot be reliably parsed (e.g., output format is non-standard,
+or only raw numbers are printed), **report the raw benchmark output** to the user instead of
+attempting to compute speedup. Let the user interpret the results:
+
+```
+Benchmark completed, but speedup could not be automatically parsed. Raw output below:
+<raw output>
+```
+
+---
+
+## Step 9: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Target Repository: <project_name>
+Generation Mode: New / Replace Existing / Custom Variant (v2)
+Operator Type: <func_type>
+
+File Changes:
+  - [New/Modified] <kernel_file_path>           (Triton kernel)
+  - [Modified] <init_file_path>                   (Registration, if applicable)
+  - [New/Modified] <test_file_path>             (Accuracy Tests)
+  - [New/Modified] <benchmark_file_path>        (Performance Benchmark)
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (config details)
+  Worst Speedup: <X.XX>x (config details)
+  (If benchmark was not run, failed, or could not be parsed, write "Incomplete" and explain the reason)
+
+MCP Iterations: <1, 2, or 3> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern"
+   - Unable to parse → Skip this section>
+
+Issues and Fixes: (if any)
+```
+
+**How to extract the numbers:**
+- **Pass/fail counts**: Parse pytest output for the line matching `X passed` or `X passed, Y failed`.
+  Use regex pattern `(\d+) passed` and `(\d+) failed` to extract.
+- **Speedup**: Parse benchmark output for kernel vs PyTorch time ratios. Calculate
+  `speedup = torch_time / kernel_time` for each config. Report min, max, and average.
+  - Use these regex patterns to extract timing values:
+    - `(\d+(?:\.\d+)?)\s*(us|ms|s)` — number with unit
+    - `(?i)mean:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — mean timing (pytest-benchmark format, e.g., `mean: 0.123 ms`)
+    - `(?i)avg:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — average timing value
+    - `(?i)median:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — median timing value
+    - `(?i)(triton|kernel).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — kernel time
+    - `(?i)(torch|pytorch|reference).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch reference time
+  - **Do not just copy the raw table** — always compute and report the actual speedup ratios.
+  - If parsing fails, report "Unable to parse" and include the raw output.
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user:
+  ```
+  ⚠️ The currently generated Triton kernel performs worse than the PyTorch reference implementation.
+  This is typically caused by suboptimal memory access patterns or improper block size configuration.
+  Would you like to use /kernelgen_optimizer to optimize this kernel's performance?
+  ```
+
+- **If average speedup is 0.5x ~ 1.2x**, ask the user:
+  ```
+  Current speedup is low (<X.XX>x) and there may be room for optimization.
+  Would you like to use /kernelgen_optimizer to try improving performance?
+  ```
+
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+---
+
+## Step 10: Post-Completion Actions
+
+After the summary is presented (whether based on MCP reports or local test results), perform
+the following two checks.
+
+### 10a. Chat Tool Notification
+
+If the user's task was received via a chat tool (e.g., Feishu/飞书, Discord, Slack, Teams,
+DingTalk/钉钉, WeChat Work/企业微信, Telegram, or any similar messaging platform), or if
+the user mentions sending results to a client or team, ask:
+
+> The operator generation is complete. Would you like me to prepare a message to send the
+> generated files or summary to your client/team via **<chat_tool_name>**?
+
+If the user confirms:
+1. Prepare a concise summary message including: operator name, file paths, accuracy pass
+   rate, speedup metrics, and any issues.
+2. If the chat tool has a CLI or API integration available in the environment (e.g., `lark`
+   CLI for Feishu, `discord` webhook, `slack` CLI), use it to send the message directly.
+3. If no CLI/API is available, format the message as copy-paste ready text for the user.
+4. If files need to be sent, list the exact file paths the user should attach.
+
+### 10b. Git Repository PR Submission
+
+Check whether the current project is managed by a git-based hosting service:
+
+```bash
+git remote -v 2>/dev/null | head -5
+```
+
+Detect the hosting platform from the remote URL:
+- `github.com` → GitHub
+- `gitlab.com` (or self-hosted GitLab) → GitLab
+- `gitee.com` → Gitee
+- `bitbucket.org` → Bitbucket
+- Other git hosting → Generic git platform
+
+**If a git hosting platform is detected**, ask the user:
+
+> This project is hosted on **<platform>**. Would you like me to automatically create a
+> Pull Request with the generated operator code?
+
+**If the user confirms**, follow the standard PR creation workflow:
+
+1. **Create a new branch**:
+   ```bash
+   git checkout -b kernelgen/<kernel_name>
+   ```
+   (Use `kernelgen/<kernel_name>-v2` for custom variants.)
+
+2. **Stage all changed/new files** related to this operator generation:
+   ```bash
+   git add <kernel_file> <test_file> <benchmark_file> <registration_files...>
+   ```
+   Only stage files that were created or modified by this skill. Never use `git add -A`.
+
+3. **Create a commit** with a descriptive message:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   Add <kernel_name> operator via KernelGen
+
+   Generated <kernel_name> (<func_type>) operator using KernelGen MCP service.
+   Includes Triton kernel implementation, accuracy tests, and performance benchmarks.
+
+   EOF
+   )"
+   ```
+
+4. **Push the branch** to the remote:
+   ```bash
+   git push -u origin kernelgen/<kernel_name>
+   ```
+
+5. **Create the PR** using the platform's CLI tool:
+
+   **For GitHub** (`gh`):
+   ```bash
+   gh pr create --title "Add <kernel_name> operator via KernelGen" --body "$(cat <<'EOF'
+   ## Summary
+   Add `<kernel_name>` operator (<func_type>) generated via KernelGen MCP service.
+
+   ## Changes
+   - [New/Modified] `<kernel_file_path>` — Triton kernel implementation
+   - [New/Modified] `<test_file_path>` — Accuracy tests
+   - [New/Modified] `<benchmark_file_path>` — Performance benchmarks
+   - [Modified] `<registration_files>` — Operator registration (if applicable)
+
+   ## Test Results
+
+   ### Accuracy
+   - **Pass rate**: <N>/<total> (<percentage>%)
+   - **Failed cases**: <list or "None">
+
+   ### Performance
+   - **Avg speedup**: <X.XX>x vs PyTorch reference
+   - **Best**: <X.XX>x | **Worst**: <X.XX>x
+
+   ## Generation Details
+   - **MCP iterations**: <count>
+   - **Target device**: <device>
+   - **Operator type**: <func_type>
+
+   ---
+   Generated by KernelGen MCP skill
+
+   EOF
+   )"
+   ```
+
+   **For Gitee** (no standard CLI — provide URL):
+   ```
+   Please create a PR manually at:
+   https://gitee.com/<owner>/<repo>/pull/new/<branch_name>
+
+   I have prepared the PR description above — you can copy-paste it.
+   ```
+
+   **For GitLab** (`glab` if available, otherwise provide URL):
+   ```bash
+   glab mr create --title "Add <kernel_name> operator via KernelGen" --description "..."
+   ```
+
+6. **Return the PR URL** to the user:
+   ```
+   ✅ Pull Request created: <PR_URL>
+   ```
+
+**If PR creation fails** (no CLI tool, no permissions, authentication issues, etc.):
+- Report the error to the user
+- Provide the branch name: `kernelgen/<kernel_name>`
+- Suggest they create the PR manually with the prepared description
+
+**If the user declines the PR**, do nothing — the changes remain as local uncommitted files
+(or on the current branch if already committed).
+
+---
+
+## Important Notes
+
+- **Dynamically discover everything** — never hardcode file paths or conventions. Always read
+  existing code first and follow the local patterns.
+- **Never overwrite existing operators** without explicit user permission (Step 3 choice).
+- **Always ask the user before installing packages** — never run `pip install` without confirmation.
+- **Match existing code style exactly** — imports, decorators, naming, logging, license headers.
+  The generated code must look like it was written by the same team.
+- **Use proper tools for all file operations**: Read to read files, Write to create new files,
+  Edit to modify existing files. Never use Write to overwrite an existing file — use Edit.
+- **Always run both accuracy AND performance tests** — don't stop at one.
+- **Use per-dtype tolerances** in tests: fp32 → 1e-5, fp16 → 1e-2, bf16 → 2e-2.
+- **Always use `ref_impl` for benchmark baselines**, not `torch.<op>` — many custom/fused
+  kernels have no single torch equivalent.
+- **Only rewrite to wrapper style when the repo explicitly uses wrappers**. Otherwise keep the
+  MCP-generated raw Triton code — this is the safer default.
+- **For raw Triton repos**: only add `@triton.autotune` if existing kernels use it. If the repo
+  does not use autotune, do NOT introduce it — use a fixed BLOCK_SIZE matching the repo pattern.
+- **Follow alphabetical ordering** when adding entries to `__init__.py`, `__all__`, or config lists.
+- If accuracy tests fail, try to fix. If benchmark is slow, consider calling
+  `mcp__kernelgen-mcp__optimize_triton` to optimize.
+- **Speedup formula**: `speedup = torch_latency / kernel_latency` (>1.0 means kernel is faster).
+  If parsing fails, report raw output instead.
+- **Never modify unrelated files**. Keep the diff minimal and focused.
+- **Use Chinese for user-facing messages** if the user communicates in Chinese.

--- a/kernelgen-mcp/kernelgen-submit-feedback.md
+++ b/kernelgen-mcp/kernelgen-submit-feedback.md
@@ -1,0 +1,407 @@
+
+# Submit Feedback Skill
+
+Submit issues to:
+
+https://github.com/flagos-ai/skills
+
+when users report bugs, defects, or improvements in skills.
+
+If the user does not want to create a GitHub account, they can instead send feedback via email:
+
+contact@flagos.io (for users without GitHub accounts)
+
+---
+
+# Prerequisites
+
+For GitHub submission:
+
+- GitHub CLI (`gh`) must be installed
+- The user must be authenticated
+
+---
+
+# Workflow
+
+## 1. Determine Submission Method
+
+**Default to GitHub Issue** unless the user explicitly prefers email or says they don't have
+a GitHub account. Do not ask for a preference unprompted — assume GitHub and proceed.
+
+If the user indicates they prefer email or don't have a GitHub account, switch to the
+Email Workflow.
+
+---
+
+# GitHub Workflow
+
+## 2. Gather Information
+
+Collect the following information from the user. **If the user already provided some of
+this information in the conversation, reuse it instead of asking again.**
+
+Required:
+
+- Skill name — **Infer from conversation context if obvious** (e.g., if the user says
+  "kernelgen skill crashes", auto-fill `kernelgen`). Only ask the user if the skill name
+  cannot be determined from context.
+- Problem description
+- Expected behavior
+- Actual behavior
+
+Optional (ask, but do not block on these):
+
+- Steps to reproduce
+
+## 3. Auto-collect Environment Information
+
+**Attempt** to collect environment information using the Bash tool. If the Bash tool is
+unavailable or the command fails, **do not block the workflow** — mark all environment
+fields as "Not detected" and continue.
+
+```bash
+if command -v python3 >/dev/null 2>&1; then
+  python3 - <<'PY'
+import platform, sys
+print(f"OS: {platform.system()} {platform.release()}")
+print(f"Python: {sys.version.split()[0]}")
+try:
+    import torch
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CUDA: {torch.version.cuda or 'not detected'}")
+except ImportError:
+    print("PyTorch: not installed")
+    print("CUDA: not detected")
+try:
+    import triton
+    print(f"Triton: {triton.__version__}")
+except ImportError:
+    print("Triton: not installed")
+PY
+elif command -v python >/dev/null 2>&1; then
+  python - <<'PY'
+import platform, sys
+print(f"OS: {platform.system()} {platform.release()}")
+print(f"Python: {sys.version.split()[0]}")
+try:
+    import torch
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CUDA: {torch.version.cuda or 'not detected'}")
+except ImportError:
+    print("PyTorch: not installed")
+    print("CUDA: not detected")
+try:
+    import triton
+    print(f"Triton: {triton.__version__}")
+except ImportError:
+    print("Triton: not installed")
+PY
+else
+  echo "PYTHON_NOT_FOUND"
+fi
+```
+
+If the output contains `PYTHON_NOT_FOUND`, or the command fails for any other reason,
+use the fallback values and move on:
+
+```
+- OS: Not detected (environment probe failed)
+- Python: Not detected (environment probe failed)
+- PyTorch: Not detected (environment probe failed)
+- CUDA: Not detected (environment probe failed)
+- Triton: Not detected (environment probe failed)
+```
+
+Include the output (or fallback values) in the Environment section of the issue.
+
+---
+
+## 4. Verify GitHub CLI
+
+First check if `gh` is installed, then check authentication:
+
+```bash
+command -v gh || echo "GH_NOT_FOUND"
+```
+
+**If the output contains the literal string `GH_NOT_FOUND`** (or is empty), **automatically
+fall back to the Email Workflow** (see below). Tell the user:
+
+    GitHub CLI (gh) was not detected on this system.
+    I will prepare an email draft instead so you can send the feedback easily.
+
+Do not stop or ask the user to install `gh` unless they explicitly want to use GitHub.
+
+**If `gh` is installed**, check authentication:
+
+```bash
+gh auth status 2>&1
+```
+
+Parse the output to determine auth state:
+- Output contains `Logged in to` or `Logged into` → authenticated, proceed.
+- Output contains `not logged in` or `authentication` error → NOT authenticated.
+- Output contains `token` and `expired` → token expired, treat as NOT authenticated.
+
+If NOT authenticated, instruct the user to run:
+
+    gh auth login
+
+Do not proceed until authentication is confirmed.
+
+---
+
+## 5. Determine Issue Type and Labels
+
+Automatically determine the issue category based on the user's report.
+
+Label rules:
+
+- If the report describes something broken or incorrect → label: `bug`
+- If the user requests a new feature or enhancement → label: `enhancement`
+- If the user suggests improvement or feedback → label: `enhancement`
+
+Always add the `skill` label as well.
+
+**Important**: Before using any label, verify it exists in the target repo. Use `--label`
+only for labels confirmed to exist. If a label does not exist, omit it rather than causing
+the `gh issue create` command to fail.
+
+To check available labels:
+
+```bash
+gh label list --repo flagos-ai/skills --limit 200 --json name
+```
+
+This outputs a JSON array like `[{"name":"bug"},{"name":"enhancement"}]`. **Extract all
+`"name"` values from the JSON array into a flat list (e.g., `["bug","enhancement","skill"]`)
+and only include `--label` flags for labels that appear in that list.** Label names are
+case-sensitive on GitHub — match them exactly as they appear in the JSON. If a desired label
+(e.g., `bug`, `skill`) does not appear, omit it from the `gh issue create` command entirely.
+Using a non-existent label will cause the command to fail.
+
+---
+
+## 6. Construct the Issue
+
+Title format:
+
+    [skill-name] Brief description
+
+Keep titles under 80 characters (preferred: under 60 for better GitHub UI display).
+**If the title exceeds 80 characters, shorten the description
+portion first** (not the skill name prefix). Do not simply truncate mid-word — rephrase the
+description to be more concise.
+
+**Generate a clear, specific title** — do not use vague user phrases like "it doesn't work"
+as-is. Summarize the actual problem based on the information gathered in Step 2. Examples:
+- Bad: `[kernelgen] it doesn't work`
+- Good: `[kernelgen] MCP call fails with schema mismatch on func_type`
+- Bad: `[submit-feedback] bug`
+- Good: `[submit-feedback] gh issue create fails when label does not exist`
+
+**If insufficient information is available** to generate a specific title, use a short generic
+description rather than guessing details. Only include facts the user actually stated.
+
+**Title uniqueness**: If you are aware that an issue with the same title already exists in
+the repo, slightly rephrase the description to make the title more specific and avoid
+duplicates.
+
+Body template (stored as a variable for use in Step 8):
+
+```
+## Skill
+
+<skill-name>
+
+## Description
+
+<description>
+
+## Steps to Reproduce
+
+<steps or "Not provided">
+
+## Expected Behavior
+
+<expected behavior>
+
+## Actual Behavior
+
+<actual behavior>
+
+## Environment
+
+- OS: <auto-collected or "Not detected">
+- Python: <auto-collected or "Not detected">
+- PyTorch: <auto-collected or "Not detected">
+- CUDA: <auto-collected or "Not detected">
+- Triton: <auto-collected or "Not detected">
+
+## Additional Context
+
+<If relevant error messages, logs, or conversation context are available, include them here.
+If the user pasted logs or stack traces earlier in the conversation, include them automatically.
+If logs exceed ~2000 characters, truncate to the most relevant portion (typically the last
+error and surrounding context) and append "... (log truncated, showing last relevant section)".
+Otherwise write "None".>
+
+---
+
+Submitted via submit-feedback skill
+```
+
+---
+
+## 7. Confirm With User
+
+Show the generated issue title, body, and labels to the user and ask for confirmation before
+submitting. Do not submit without explicit user approval.
+
+---
+
+## 8. Submit the Issue
+
+**Use `--body-file -` with a HEREDOC** to pass the body via stdin. This avoids shell escaping
+issues with multiline markdown and the "Argument list too long" error for large bodies:
+
+**Important**: The `--label` flags in the example above are illustrative. **Only include labels
+verified to exist** in Step 5. If `bug` or `skill` does not appear in the `gh label list`
+output, omit that `--label` flag entirely. Example with no verified labels:
+
+```bash
+gh issue create \
+  --repo flagos-ai/skills \
+  --title "[skill-name] Brief description" \
+  --body-file - <<'__ISSUE_BODY_FLAGOS_SKILL__'
+## Skill
+
+<skill-name>
+
+## Description
+
+<description>
+
+## Steps to Reproduce
+
+<steps or "Not provided">
+
+## Expected Behavior
+
+<expected behavior>
+
+## Actual Behavior
+
+<actual behavior>
+
+## Environment
+
+- OS: ...
+- Python: ...
+- PyTorch: ...
+- CUDA: ...
+- Triton: ...
+
+## Additional Context
+
+<error messages, logs, or relevant conversation context — or "None">
+
+---
+
+Submitted via submit-feedback skill
+__ISSUE_BODY_FLAGOS_SKILL__
+```
+
+**Never use `"$BODY"` with shell variable expansion** or `--body "$(cat ...)"` — multiline
+markdown content with backticks, quotes, and special characters will break the command.
+Always use `--body-file -` with HEREDOC as shown above.
+
+---
+
+## 9. Confirm Creation
+
+Show the created issue URL and number.
+
+Example:
+
+    Issue #42 created: https://github.com/flagos-ai/skills/issues/42
+
+If the command fails, show the error to the user and suggest they create the issue manually
+at https://github.com/flagos-ai/skills/issues/new with the body text you prepared.
+
+---
+
+# Email Workflow (Alternative)
+
+The Email Workflow is used when:
+- The user explicitly prefers email
+- The user does not have a GitHub account
+- GitHub CLI (`gh`) is not available (automatic fallback from Step 4)
+
+Prepare an email draft and provide a `mailto:` link.
+
+Recipient:
+
+    contact@flagos.io
+
+Subject:
+
+    [Skill Feedback] <skill-name> - Brief description
+
+Body template:
+
+```
+Skill: <skill-name>
+
+Description:
+<description>
+
+Steps to Reproduce:
+<steps or "Not provided">
+
+Expected Behavior:
+<expected behavior>
+
+Actual Behavior:
+<actual behavior>
+
+Environment:
+- OS: <auto-collected or "Not detected">
+- Python: <auto-collected or "Not detected">
+- PyTorch: <auto-collected or "Not detected">
+- CUDA: <auto-collected or "Not detected">
+- Triton: <auto-collected or "Not detected">
+
+Additional Context:
+<error messages, logs, or relevant conversation context — or "None">
+
+Submitted via skill feedback email
+```
+
+After showing the draft, provide **two options** for the user:
+
+1. **mailto link** (for users with a configured email client):
+   ```
+   mailto:contact@flagos.io?subject=[Skill Feedback] <skill-name> - Brief description&body=<url-encoded body>
+   ```
+   **URL-encode the body text** before inserting it into the mailto link (spaces → `%20`,
+   newlines → `%0A`, etc.). Unencoded special characters will break the link.
+   **Note**: `mailto:` links have a ~2000 character limit. If the URL-encoded body exceeds
+   this, skip the mailto link and only offer option 2.
+2. **Copy-paste**: Tell the user to copy the draft above and send it manually to
+   `contact@flagos.io`. This is the most reliable option and works regardless of email
+   client or body length.
+
+---
+
+# Rules
+
+- Always confirm the issue or email content before sending.
+- Never fabricate details. If information is missing, write "Not provided".
+- Auto-collect environment info — do not ask the user for OS/Python/PyTorch versions.
+- Keep submissions in English. If the user provides Chinese text, translate it before submission.
+- If `gh` or authentication is not available, do not attempt workarounds — guide the user
+  to install/authenticate or switch to the email workflow.
+- Do not include sensitive information (API keys, tokens, passwords) in the issue body.
+  If the user's logs contain secrets, redact them before submission.


### PR DESCRIPTION
## Summary

  - Add 4 KernelGen Claude Code skills that automate GPU kernel generation via the `kernelgen-mcp` MCP service: a general-purpose skill, two framework-specific skills (FlagGems, vLLM), and a feedback submission skill
  - Each generation skill implements a full 8-step pipeline: environment check → MCP availability → operator aliasing → code generation → file placement → accuracy testing → benchmarking → summary report
  - The feedback skill provides a structured GitHub issue workflow for reporting bugs and improvements

  ## Skills

  | Skill | Description | SKILL.md |
  |-------|-------------|----------|
  | `kernelgen` | General-purpose GPU kernel generation for any Python/Triton project | 971 lines |
  | `kernelgen-for-flaggems` | FlagGems-specific generation with promotion rules, `pointwise_dynamic` wrappers, and `_FULL_CONFIG` registration | 882 lines |
  | `kernelgen-for-vllm` | vLLM-specific generation with SPDX headers, `vllm.logger`, `@triton.autotune`, and custom op registration | 1020 lines |
  | `kernelgen-submit-feedback` | Submit bug reports / improvement suggestions as GitHub issues to flagos-ai/skills | 435 lines |

  ## Key Techniques

  | Technique | Description |
  |-----------|-------------|
  | MCP-driven code generation | Calls `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton` to produce Triton kernel code, avoiding hand-written GPU code entirely |
  | Operator alias resolution | 13-entry alias table normalizes natural-language operator names (e.g., `square_root → sqrt`, `cube → pow (exp=3)`) before MCP calls |
  | `func_type` auto-inference | Pattern-based rules infer kernel category (activation, norm, attention, quantization, etc.) from the operator name, reducing user input |
  | Multi-pass error recovery | 4-step retry protocol: self-fix → MCP re-generate → MCP optimize with error context → stop and report. Strictly bounded to prevent infinite loops |
  | `inspect.signature` smoke test | Introspects the generated kernel's function signature to infer missing arguments (weight, bias, eps) before constructing smoke tests |
  | Benchmark regex extraction | 6 regex patterns extract timing values from diverse benchmark output formats (mean, avg, median, raw units, Triton-specific, PyTorch reference) |
  | MCP prerequisite check | If `kernelgen-mcp` is not configured, directs users to https://kernelgen.flagos.io/ for setup instructions |


 ## Update

  1. Rename skill: kernelgen → kernelgen-flagos

  - Folder renamed from kernelgen/ to kernelgen-flagos/
  - SKILL.md frontmatter name field updated accordingly
  - Skill is now invocable via /kernelgen-flagos

  2. Five workflow optimizations added to all sub-skills

  The following optimizations are applied consistently across kernelgen-general.md, kernelgen-for-vllm.md, and kernelgen-for-flaggems.md:

  (1) MCP Mandatory Enforcement

  - Added to SKILL.md rule 6 and each sub-skill's Execution Rules
  - ALL operator code generation must go through mcp__kernelgen-mcp__generate_operator
  - The model is explicitly forbidden from self-writing Triton kernels, PyTorch wrappers, or operator implementations
  - If MCP is not configured, unreachable, or fails after retries, the skill must STOP and report — never fall back to manual code generation

  (2) MCP Test Report Review

  - New step inserted after the MCP call (Step 5.5 / 4.5 / 4.5 depending on sub-skill)
  - When MCP returns test results (accuracy tests and/or benchmark speedup reports), the full report is displayed to the user
  - User is prompted to choose:
    - (A) Accept MCP results, skip local testing
    - (B) Run local tests for additional verification

  (3) Chip Compatibility Check

  - New step inserted before local test execution (Step 6.5d / 5.5 / 5.5c)
  - Runs a hardware detection script that checks for:
    - NVIDIA GPU (nvidia-smi, torch.cuda)
    - Huawei Ascend NPU (npu-smi info)
    - Hygon DCU / AMD ROCm (rocm-smi)
    - Moore Threads (mtsmi, torch_musa)
    - Tianshu (ixsmi)
    - Cambricon MLU (cnmon)
  - Compares detected hardware against the target device specified for the operator
  - If mismatch is detected, warns the user and offers:
    - (A) Skip local testing (recommended when hardware doesn't match)
    - (B) Proceed anyway (user accepts risk of failure)

  (4) Chat Tool Notification

  - New post-completion step (Step 10a / 9a / 9a)
  - Detects if the task originated from a chat tool (Feishu/Lark, Discord, Slack, DingTalk, WeChat Work, etc.)
  - If so, asks the user whether to send generated files and/or a summary back through the chat tool

  (5) Automated PR Submission

  - New post-completion step (Step 10b / 9b / 9b)
  - Detects the Git hosting platform via git remote -v:
    - GitHub → gh pr create
    - GitLab → glab mr create
    - Gitee → manual instructions (no CLI tool)
  - Generates a detailed PR description including:
    - Operator name, type, and target device
    - File list with placement rationale
    - Test results summary (MCP + local)
    - Platform-specific fields (e.g., FlagGems "Placement" field for core/experimental/backend)
  - Creates a feature branch, commits, pushes, and returns the PR/MR link to the user