### PR TITLE
feat(kernelgen-mcp): sync and rename skills, add optimize & specialize sub-skills

### DIFF
--- a/kernelgen-mcp/README.md
+++ b/kernelgen-mcp/README.md
@@ -10,13 +10,18 @@
 
 Writing high-performance GPU kernels is complex and error-prone. Different projects (FlagGems, vLLM, custom Triton repos) each have unique conventions for operator implementation, testing, and registration. Previously, users needed to install separate skills for each project type.
 
-This unified skill bundles **four sub-skills** into one package, so users only need a single install:
+This unified skill bundles **nine sub-skills** into one package, so users only need a single install:
 
 | Sub-skill | Purpose |
 |---|---|
-| **kernelgen-general** | Generate GPU kernels for any Python/Triton repository |
-| **kernelgen-for-flaggems** | Specialized for FlagGems (`pointwise_dynamic`, `_FULL_CONFIG`, categorized tests) |
-| **kernelgen-for-vllm** | Specialized for vLLM (SPDX headers, `init_logger`, `@triton.autotune`, custom op registration) |
+| **kernelgen-generate** | Generate GPU kernels for any Python/Triton repository |
+| **kernelgen-generate-for-flaggems** | Specialized for FlagGems (`pointwise_dynamic`, `_FULL_CONFIG`, categorized tests) |
+| **kernelgen-generate-for-vllm** | Specialized for vLLM (SPDX headers, `init_logger`, `@triton.autotune`, custom op registration) |
+| **kernelgen-optimize** | General-purpose Triton kernel optimization via MCP iterative loop |
+| **kernelgen-optimize-for-flaggems** | FlagGems-specific optimization (3 modes: built-in/external/experimental operators) |
+| **kernelgen-optimize-for-vllm** | vLLM-specific optimization with CustomOp registration and integration |
+| **kernelgen-specialize** | Platform specialization for Triton operators (e.g., GPU to Ascend NPU migration) |
+| **kernelgen-specialize-for-flaggems** | Platform specialization with FlagGems framework integration |
 | **kernelgen-submit-feedback** | Submit bug reports via GitHub Issues or email |
 
 ### Usage
@@ -28,8 +33,8 @@ This unified skill bundles **four sub-skills** into one package, so users only n
 # Generate with explicit function type
 /kernelgen-flagos rms_norm --func-type normalization
 
-# Generate for any operator
-/kernelgen-flagos silu_and_mul
+# Optimize an existing kernel
+/kernelgen-flagos optimize <operator_source_dir> [target_speedup] [max_iterations]
 ```
 
 The skill will automatically:
@@ -53,13 +58,22 @@ If you encounter any issues during generation, say "submit feedback" or "report 
 ```
 ┌──────────────────────────────────────────────────────────┐
 │  Phase 1   Detect repository type                        │
-│            ├── FlagGems? → kernelgen-for-flaggems.md     │
-│            ├── vLLM?     → kernelgen-for-vllm.md        │
-│            └── Other?    → kernelgen-general.md          │
+│            ├── FlagGems? → kernelgen-generate-for-flaggems.md │
+│            ├── vLLM?     → kernelgen-generate-for-vllm.md    │
+│            └── Other?    → kernelgen-generate.md              │
 │                                                          │
 │  Phase 2   Execute the selected sub-skill workflow       │
 │            (environment check → MCP generation →         │
 │             code adaptation → testing → benchmarking)    │
+│                                                          │
+│  Phase 2b  Optimization (if requested)                   │
+│            ├── FlagGems? → kernelgen-optimize-for-flaggems.md │
+│            ├── vLLM?     → kernelgen-optimize-for-vllm.md    │
+│            └── Other?    → kernelgen-optimize.md              │
+│                                                          │
+│  Phase 2c  Platform specialization (if requested)        │
+│            ├── FlagGems? → kernelgen-specialize-for-flaggems.md │
+│            └── Other?    → kernelgen-specialize.md              │
 │                                                          │
 │  Phase 3   Feedback handling (on demand)                 │
 │            → kernelgen-submit-feedback.md                │
@@ -71,15 +85,20 @@ If you encounter any issues during generation, say "submit feedback" or "report 
 ## Directory Structure
 
 ```
-skills/kernelgen/
-├── SKILL.md                       # Unified entry point (routing logic)
-├── kernelgen-general.md           # General-purpose sub-skill
-├── kernelgen-for-flaggems.md      # FlagGems-specific sub-skill
-├── kernelgen-for-vllm.md          # vLLM-specific sub-skill
-├── kernelgen-submit-feedback.md   # Feedback submission sub-skill
-├── LICENSE.txt                    # Apache 2.0 license
-├── README.md                      # This document (English)
-└── README_zh.md                   # Chinese version
+skills/kernelgen-flagos/
+├── SKILL.md                              # Unified entry point (routing logic)
+├── kernelgen-generate.md                 # General-purpose generation sub-skill
+├── kernelgen-generate-for-flaggems.md    # FlagGems-specific generation sub-skill
+├── kernelgen-generate-for-vllm.md        # vLLM-specific generation sub-skill
+├── kernelgen-optimize.md                 # General-purpose optimization sub-skill
+├── kernelgen-optimize-for-flaggems.md    # FlagGems-specific optimization sub-skill
+├── kernelgen-optimize-for-vllm.md        # vLLM-specific optimization sub-skill
+├── kernelgen-specialize.md               # Platform specialization sub-skill
+├── kernelgen-specialize-for-flaggems.md  # FlagGems-specific specialization sub-skill
+├── kernelgen-submit-feedback.md          # Feedback submission sub-skill
+├── LICENSE.txt                           # Apache 2.0 license
+├── README.md                             # This document (English)
+└── README_zh.md                          # Chinese version
 ```
 
 ---
@@ -90,21 +109,41 @@ skills/kernelgen/
 
 The unified entry point. Contains routing logic that auto-detects the repository type (FlagGems, vLLM, or generic) and reads the appropriate sub-skill file to execute.
 
-### `kernelgen-general.md`
+### `kernelgen-generate.md`
 
 Full 10-step workflow for generating GPU kernel operators in any Python/Triton repository. Includes dynamic repo structure discovery, convention detection, and adaptive code placement.
 
-### `kernelgen-for-flaggems.md`
+### `kernelgen-generate-for-flaggems.md`
 
 9-step workflow specialized for FlagGems repositories. Handles `pointwise_dynamic` wrappers, promotion methods, `_FULL_CONFIG` registration, categorized test files, and FlagGems-specific conventions.
 
-### `kernelgen-for-vllm.md`
+### `kernelgen-generate-for-vllm.md`
 
 9-step workflow specialized for vLLM repositories. Handles SPDX license headers, `vllm.logger.init_logger`, `@triton.autotune`, custom op registration, and vLLM directory conventions.
 
 ### `kernelgen-submit-feedback.md`
 
 Feedback submission workflow. Collects bug reports with auto-detected environment info and submits via GitHub Issues (`gh` CLI) or email fallback.
+
+### `kernelgen-optimize.md`
+
+General-purpose Triton kernel optimization via MCP iterative loop. Analyzes existing kernels, identifies bottlenecks, and applies optimizations through multiple rounds until the target speedup is reached.
+
+### `kernelgen-optimize-for-flaggems.md`
+
+FlagGems-specific kernel optimization with 3 modes: optimize built-in operators in-place, optimize external operators and integrate into experimental_ops, or optimize existing experimental operators. Includes accuracy tests and performance benchmarks.
+
+### `kernelgen-optimize-for-vllm.md`
+
+vLLM-specific kernel optimization with CustomOp registration, accuracy tests, and performance benchmark integration. Optimizes Triton operators and automatically integrates them into the vLLM project.
+
+### `kernelgen-specialize.md`
+
+Platform specialization for Triton operators via MCP `specialize_kernel` tool. Migrates GPU Triton operators to target platforms (e.g., Huawei Ascend NPU), handling architecture differences, Grid configuration, UB overflow, and memory alignment.
+
+### `kernelgen-specialize-for-flaggems.md`
+
+Combines MCP platform specialization with FlagGems framework integration. Supports four integration modes: vendor-ops (default), vendor-fused, override-builtin, and experimental. Includes automated testing and performance benchmarking.
 
 ---
 

--- a/kernelgen-mcp/README_zh.md
+++ b/kernelgen-mcp/README_zh.md
@@ -8,13 +8,18 @@
 
 编写高性能 GPU 算子复杂且容易出错。不同项目（FlagGems、vLLM、自定义 Triton 仓库）各自有独特的算子实现规范、测试模式和注册系统。此前，用户需要分别安装多个技能。
 
-本统一技能将 **四个子技能** 打包为一个，用户只需安装一次：
+本统一技能将 **九个子技能** 打包为一个，用户只需安装一次：
 
 | 子技能 | 用途 |
 |---|---|
-| **kernelgen-general** | 为任意 Python/Triton 仓库生成 GPU 算子 |
-| **kernelgen-for-flaggems** | FlagGems 专用（`pointwise_dynamic`、`_FULL_CONFIG`、分类测试） |
-| **kernelgen-for-vllm** | vLLM 专用（SPDX 头、`init_logger`、`@triton.autotune`、自定义算子注册） |
+| **kernelgen-generate** | 为任意 Python/Triton 仓库生成 GPU 算子 |
+| **kernelgen-generate-for-flaggems** | FlagGems 专用（`pointwise_dynamic`、`_FULL_CONFIG`、分类测试） |
+| **kernelgen-generate-for-vllm** | vLLM 专用（SPDX 头、`init_logger`、`@triton.autotune`、自定义算子注册） |
+| **kernelgen-optimize** | 通用 Triton 内核优化，通过 MCP 迭代循环进行多轮优化 |
+| **kernelgen-optimize-for-flaggems** | FlagGems 专用优化（3 种模式：内置/外部/实验性算子） |
+| **kernelgen-optimize-for-vllm** | vLLM 专用优化，含 CustomOp 注册和集成 |
+| **kernelgen-specialize** | 平台特化，将 Triton 算子迁移到目标平台（如 GPU → 昇腾 NPU） |
+| **kernelgen-specialize-for-flaggems** | 平台特化 + FlagGems 框架集成，支持 4 种集成模式 |
 | **kernelgen-submit-feedback** | 通过 GitHub Issues 或邮件提交 bug 报告 |
 
 ### 使用方式
@@ -26,8 +31,8 @@
 # 指定函数类型
 /kernelgen-flagos rms_norm --func-type normalization
 
-# 生成任意算子
-/kernelgen-flagos silu_and_mul
+# 优化已有算子
+/kernelgen-flagos optimize <算子源目录> [目标加速比] [最大迭代次数]
 ```
 
 技能会自动：
@@ -51,13 +56,22 @@
 ```
 ┌──────────────────────────────────────────────────────────┐
 │  阶段 1   检测仓库类型                                     │
-│           ├── FlagGems? → kernelgen-for-flaggems.md      │
-│           ├── vLLM?     → kernelgen-for-vllm.md         │
-│           └── 其他?     → kernelgen-general.md           │
+│           ├── FlagGems? → kernelgen-generate-for-flaggems.md │
+│           ├── vLLM?     → kernelgen-generate-for-vllm.md    │
+│           └── 其他?     → kernelgen-generate.md              │
 │                                                          │
 │  阶段 2   执行选定的子技能工作流                            │
 │           （环境检查 → MCP 生成 →                          │
 │            代码适配 → 测试 → 性能基准测试）                  │
+│                                                          │
+│  阶段 2b  优化（按需）                                     │
+│           ├── FlagGems? → kernelgen-optimize-for-flaggems.md │
+│           ├── vLLM?     → kernelgen-optimize-for-vllm.md    │
+│           └── 其他?     → kernelgen-optimize.md              │
+│                                                          │
+│  阶段 2c  平台特化（按需）                                   │
+│           ├── FlagGems? → kernelgen-specialize-for-flaggems.md │
+│           └── 其他?     → kernelgen-specialize.md              │
 │                                                          │
 │  阶段 3   反馈处理（按需）                                  │
 │           → kernelgen-submit-feedback.md                  │
@@ -70,14 +84,19 @@
 
 ```
 skills/kernelgen-flagos/
-├── SKILL.md                       # 统一入口（路由逻辑）
-├── kernelgen-general.md           # 通用子技能
-├── kernelgen-for-flaggems.md      # FlagGems 专用子技能
-├── kernelgen-for-vllm.md          # vLLM 专用子技能
-├── kernelgen-submit-feedback.md   # 反馈提交子技能
-├── LICENSE.txt                    # Apache 2.0 许可证
-├── README.md                      # 英文文档
-└── README_zh.md                   # 本文档（中文版）
+├── SKILL.md                              # 统一入口（路由逻辑）
+├── kernelgen-generate.md                 # 通用生成子技能
+├── kernelgen-generate-for-flaggems.md    # FlagGems 专用生成子技能
+├── kernelgen-generate-for-vllm.md        # vLLM 专用生成子技能
+├── kernelgen-optimize.md                 # 通用优化子技能
+├── kernelgen-optimize-for-flaggems.md    # FlagGems 专用优化子技能
+├── kernelgen-optimize-for-vllm.md        # vLLM 专用优化子技能
+├── kernelgen-specialize.md               # 平台特化子技能
+├── kernelgen-specialize-for-flaggems.md  # FlagGems 专用特化子技能
+├── kernelgen-submit-feedback.md          # 反馈提交子技能
+├── LICENSE.txt                           # Apache 2.0 许可证
+├── README.md                             # 英文文档
+└── README_zh.md                          # 本文档（中文版）
 ```
 
 ---

--- a/kernelgen-mcp/SKILL.md
+++ b/kernelgen-mcp/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: kernelgen-flagos
 description: >
-  Unified GPU kernel operator generation skill. Automatically detects the target repository type
-  (FlagGems, vLLM, or general Python/Triton) and dispatches to the appropriate specialized
-  sub-skill. Also includes a feedback submission sub-skill for bug reports. Use this skill when
-  the user wants to generate a GPU kernel operator, create a Triton kernel, or says things like
-  "generate an operator", "create a kernel for X", or "/kernelgen-flagos". This single skill replaces
-  the need to install kernelgen-general, kernelgen-for-flaggems, kernelgen-for-vllm, and
-  kernelgen-submit-feedback separately.
+  Unified GPU kernel operator generation and optimization skill. Automatically detects the target
+  repository type (FlagGems, vLLM, or general Python/Triton) and dispatches to the appropriate
+  specialized sub-skill. Includes operator generation, MCP-based iterative optimization, and
+  feedback submission sub-skills. Use this skill when the user wants to generate or optimize a
+  GPU kernel operator, create a Triton kernel, or says things like "generate an operator",
+  "create a kernel for X", "optimize triton kernel", or "/kernelgen-flagos".
 argument-hint: "<operator_name> [--func-type <type>]"
 user-invokable: true
 compatibility: "Python 3.8+, PyTorch with CUDA, Triton"
@@ -15,7 +14,7 @@ metadata:
   version: "1.0.0"
   author: flagos-ai
   category: gpu-kernel-generation
-  tags: [kernelgen, triton, gpu, mcp, operator-generation, flaggems, vllm, feedback]
+  tags: [kernelgen, triton, gpu, mcp, operator-generation, operator-optimization, flaggems, vllm, feedback]
 allowed-tools:
   - Bash
   - Bash(gh:*)
@@ -32,13 +31,22 @@ allowed-tools:
 
 # kernelgen-flagos — Unified GPU Operator Generation Skill
 
-This is a **unified entry point** that bundles four sub-skills into one:
+This is a **unified entry point** that bundles generation and optimization sub-skills into one:
 
 | Sub-skill file | Purpose |
 |---|---|
-| `kernelgen-general.md` | Generate GPU kernels for **any** Python/Triton repository |
-| `kernelgen-for-flaggems.md` | Specialized generation for **FlagGems** repositories |
-| `kernelgen-for-vllm.md` | Specialized generation for **vLLM** repositories |
+| **Generation** | |
+| `kernelgen-generate.md` | Generate GPU kernels for **any** Python/Triton repository |
+| `kernelgen-generate-for-flaggems.md` | Specialized generation for **FlagGems** repositories |
+| `kernelgen-generate-for-vllm.md` | Specialized generation for **vLLM** repositories |
+| **Optimization** | |
+| `kernelgen-optimize.md` | Optimize existing Triton kernels via MCP iterative optimization (general purpose) |
+| `kernelgen-optimize-for-flaggems.md` | Optimize Triton operators and integrate into **FlagGems** (3 modes: built-in/external/experimental) |
+| `kernelgen-optimize-for-vllm.md` | Optimize Triton operators and integrate into **vLLM** (with CustomOp registration) |
+| **Platform Specialization** | |
+| `kernelgen-specialize.md` | Specialize Triton operators to target platforms (e.g., GPU → Ascend NPU) via MCP `specialize_kernel` |
+| `kernelgen-specialize-for-flaggems.md` | Platform specialization + **FlagGems** integration (4 modes: vendor-ops/vendor-fused/override-builtin/experimental) |
+| **Feedback** | |
 | `kernelgen-submit-feedback.md` | Submit bug reports and feedback via GitHub or email |
 
 All sub-skill files are located in the **same directory** as this `SKILL.md` file.
@@ -81,18 +89,40 @@ from this skill's directory, then **follow the instructions in that file exactly
 Glob tool to find the path:
 
 ```
-Glob: **/skills/kernelgen-flagos/kernelgen-general.md
+Glob: **/skills/kernelgen-flagos/kernelgen-generate.md
 ```
 
 Then use the Read tool to read the matched path.
 
 #### Decision Table
 
+**Generation requests** (user wants to create/generate a new operator):
+
 | Detection Result | Action |
 |---|---|
-| FlagGems repository detected | Read `kernelgen-for-flaggems.md` and follow it |
-| vLLM repository detected | Read `kernelgen-for-vllm.md` and follow it |
-| Neither detected (or unknown) | Read `kernelgen-general.md` and follow it |
+| FlagGems repository detected | Read `kernelgen-generate-for-flaggems.md` and follow it |
+| vLLM repository detected | Read `kernelgen-generate-for-vllm.md` and follow it |
+| Neither detected (or unknown) | Read `kernelgen-generate.md` and follow it |
+
+**Optimization requests** (user wants to optimize an existing operator, mentions "optimize", "speedup", "improve performance"):
+
+| Detection Result | Action |
+|---|---|
+| FlagGems repository detected | Read `kernelgen-optimize-for-flaggems.md` and follow it |
+| vLLM repository detected | Read `kernelgen-optimize-for-vllm.md` and follow it |
+| Neither detected (or unknown) | Read `kernelgen-optimize.md` and follow it |
+
+**Specialization requests** (user wants to migrate/specialize an operator to a different platform, mentions "specialize", "migrate to Ascend/NPU", "platform migration"):
+
+| Detection Result | Action |
+|---|---|
+| FlagGems repository detected | Read `kernelgen-specialize-for-flaggems.md` and follow it |
+| Neither detected (or unknown) | Read `kernelgen-specialize.md` and follow it |
+
+**Feedback requests**:
+
+| Detection Result | Action |
+|---|---|
 | User reports a bug or requests feedback submission | Read `kernelgen-submit-feedback.md` and follow it |
 
 **Important rules:**
@@ -104,7 +134,9 @@ Then use the Read tool to read the matched path.
 5. If the user explicitly requests a specific sub-skill (e.g., "use the FlagGems version"),
    honor that request regardless of auto-detection results.
 6. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
-   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   `mcp__kernelgen-mcp__generate_kernel` MCP tool. Optimization uses
+   `mcp__kernelgen-mcp__optimize_kernel`, and platform specialization uses
+   `mcp__kernelgen-mcp__specialize_kernel`. NEVER generate Triton kernels, PyTorch
    wrappers, or operator implementations yourself. If MCP is not configured, not reachable,
    or fails after all retries, STOP and report the issue — do NOT fall back to writing code
    manually.
@@ -124,11 +156,17 @@ or asks to submit feedback about the skill:
 ## Quick Reference for Users
 
 ```bash
+# === Generation ===
 # Generate a kernel operator (auto-detects repo type)
 /kernelgen-flagos relu
 
 # Generate with explicit function type
 /kernelgen-flagos rms_norm --func-type normalization
+
+# === Optimization ===
+# Optimize an existing Triton kernel (auto-detects repo type)
+# Just say "optimize the relu kernel" or "improve kernel performance"
+# The skill will automatically dispatch to the right optimization sub-skill
 
 # The skill will automatically:
 # - Detect if you're in a FlagGems repo → use FlagGems-specific workflow

--- a/kernelgen-mcp/kernelgen-generate-for-flaggems.md
+++ b/kernelgen-mcp/kernelgen-generate-for-flaggems.md
@@ -9,7 +9,7 @@ You are an expert at generating GPU kernel operators for the FlagGems project us
 - **Write / Edit**: create or modify files
 - **Grep**: search file contents
 - **Glob**: find files by pattern
-- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+- **MCP tools**: `mcp__kernelgen-mcp__generate_kernel` and `mcp__kernelgen-mcp__optimize_kernel`
 
 > **MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
 > immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
@@ -27,7 +27,7 @@ Always use the appropriate built-in tool rather than outputting commands for the
 5. **Report progress to the user when entering each step**.
 6. **Never fabricate repository files or paths**.
 7. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
-   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   `mcp__kernelgen-mcp__generate_kernel` MCP tool. NEVER generate Triton kernels, PyTorch
    wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
    relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 4,
    STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
@@ -371,14 +371,14 @@ Before calling the MCP generator, use the Read tool to gather reference material
    - `"test pattern: @pytest.mark.xxx, POINTWISE_SHAPES, FLOAT_DTYPES, gems_assert_close"`
    - `"experimental test style: from flag_gems.experimental_ops.abs import abs as gems_abs, uses torch.ops.aten.abs for reference"`
 
-   If the `mcp__kernelgen-mcp__generate_operator` tool supports a `flagos_wiki` (or similarly named
+   If the `mcp__kernelgen-mcp__generate_kernel` tool supports a `flagos_wiki` (or similarly named
    `context`/`references`) parameter, pass the collected notes. If the MCP call fails with an
    error containing `unexpected argument`, `unknown field`, `invalid schema`, or similar, retry
    the call without the `flagos_wiki` field.
 
 ## Step 4: Call kernelgen-mcp
 
-Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above, including the
+Invoke `mcp__kernelgen-mcp__generate_kernel` with the parameters gathered above, including the
 `flagos_wiki` list for reference context.
 
 If `<placement>` is `backend` and target device is not nvidia, pass the `device` parameter to the
@@ -931,8 +931,8 @@ to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically le
 an endless fix-retry loop without converging. The MCP service has better optimization
 capabilities for these issues.
 
-**Step 6b. MCP re-generation — pass error context to generate_operator:**
-Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+**Step 6b. MCP re-generation — pass error context to generate_kernel:**
+Re-call `mcp__kernelgen-mcp__generate_kernel` with the **same parameters as Step 4**,
 but add the error information to `flagos_wiki` as additional hints.
 **Increment**: `iteration_count += 1`.
 Keep `flagos_wiki` concise — maximum 10 items total. If retrying multiple times, replace
@@ -941,8 +941,8 @@ Replace the kernel code with the new MCP output, re-run tests.
 - If tests **pass** → proceed to Step 7.
 - If tests **still fail** → proceed to Step 6c.
 
-**Step 6c. MCP optimization — pass error context to optimize_triton:**
-Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+**Step 6c. MCP optimization — pass error context to optimize_kernel:**
+Try `mcp__kernelgen-mcp__optimize_kernel` with the current kernel code and the
 `check_result` parameter containing the error traceback.
 **Increment**: `iteration_count += 1`.
 Replace the kernel code with the optimized output, re-run tests.

--- a/kernelgen-mcp/kernelgen-generate-for-vllm.md
+++ b/kernelgen-mcp/kernelgen-generate-for-vllm.md
@@ -25,7 +25,7 @@ Follow these rules strictly to avoid getting lost in the multi-step workflow:
    Glob or Grep tools, report it to the user instead of guessing. Do not assume a file exists
    at a path without verifying it first.
 8. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
-   `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+   `mcp__kernelgen-mcp__generate_kernel` MCP tool. NEVER generate Triton kernels, PyTorch
    wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
    relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 4,
    STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
@@ -341,7 +341,7 @@ flagos_wiki = [
 
 ## Step 4: Call kernelgen-mcp
 
-Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+Invoke `mcp__kernelgen-mcp__generate_kernel` with the parameters gathered above:
 
 ```
 kernel_name:  "<kernel_name>"
@@ -926,8 +926,8 @@ to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically le
 an endless fix-retry loop without converging. The MCP service has better optimization
 capabilities for these issues.
 
-**Step 6b. MCP re-generation — pass error context to generate_operator:**
-Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+**Step 6b. MCP re-generation — pass error context to generate_kernel:**
+Re-call `mcp__kernelgen-mcp__generate_kernel` with the **same parameters as Step 4**,
 but add the error information to `flagos_wiki` as additional hints:
 ```python
 flagos_wiki = [
@@ -941,8 +941,8 @@ Replace the kernel code with the new MCP output, re-run tests.
 - If tests **pass** → proceed to Step 7.
 - If tests **still fail** → proceed to Step 6c.
 
-**Step 6c. MCP optimization — pass error context to optimize_triton:**
-Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+**Step 6c. MCP optimization — pass error context to optimize_kernel:**
+Try `mcp__kernelgen-mcp__optimize_kernel` with the current kernel code and the
 `check_result` parameter containing the error traceback. This endpoint can fix
 memory access patterns, index calculations, and numerical issues.
 Replace the kernel code with the optimized output, re-run tests.
@@ -1159,7 +1159,7 @@ creation with the prepared description.
   no single torch equivalent function.
 - **Match the existing code patterns** when adding to existing files (e.g., `_custom_ops.py`, layer files).
 - If accuracy tests fail, try to fix the operator. If benchmark is slow, consider calling
-  `mcp__kernelgen-mcp__optimize_triton` to optimize the kernel.
+  `mcp__kernelgen-mcp__optimize_kernel` to optimize the kernel.
 - When creating a custom variant, always make it clear that it does NOT override existing ops
   to avoid conflicts.
 - **Always use `@torch.inference_mode()`** in tests for consistency with the codebase.

--- a/kernelgen-mcp/kernelgen-generate.md
+++ b/kernelgen-mcp/kernelgen-generate.md
@@ -12,7 +12,7 @@ placing code.
 - **Write / Edit**: create or modify files
 - **Grep**: search file contents
 - **Glob**: find files by pattern
-- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+- **MCP tools**: `mcp__kernelgen-mcp__generate_kernel` and `mcp__kernelgen-mcp__optimize_kernel`
 
 > **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., the MCP tools are unavailable or calls fail),
 > immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
@@ -41,7 +41,7 @@ Follow these rules strictly to avoid getting lost in the multi-step workflow:
    the specific discovered source, test, or benchmark directories. Unscoped searches cause
    token explosion and match vendored code, docs, and build artifacts.
 10. **CRITICAL — MCP is mandatory**: ALL operator code generation MUST go through the
-    `mcp__kernelgen-mcp__generate_operator` MCP tool. NEVER generate Triton kernels, PyTorch
+    `mcp__kernelgen-mcp__generate_kernel` MCP tool. NEVER generate Triton kernels, PyTorch
     wrappers, or operator implementations yourself — even if the operator seems simple (e.g.,
     relu, abs). If MCP is not configured, not reachable, or fails after all retries in Step 5,
     STOP and report the issue to the user. Do NOT fall back to writing kernel code manually.
@@ -456,7 +456,7 @@ generation quality:
 
 ## Step 5: Call kernelgen-mcp
 
-Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+Invoke `mcp__kernelgen-mcp__generate_kernel` with the parameters gathered above:
 
 ```
 kernel_name:     "<kernel_name>"
@@ -888,8 +888,8 @@ to Step 7b. Do NOT attempt to fix algorithm logic yourself, as this typically le
 an endless fix-retry loop without converging. The MCP service has better optimization
 capabilities for these issues.
 
-**Step 7b. MCP re-generation — pass error context to generate_operator:**
-Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 5**,
+**Step 7b. MCP re-generation — pass error context to generate_kernel:**
+Re-call `mcp__kernelgen-mcp__generate_kernel` with the **same parameters as Step 5**,
 but add the error information to `flagos_wiki` as additional hints:
 ```python
 flagos_wiki = [
@@ -903,8 +903,8 @@ Replace the kernel code with the new MCP output, re-run tests.
 - If tests **pass** → proceed to Step 8.
 - If tests **still fail** → proceed to Step 7c.
 
-**Step 7c. MCP optimization — pass error context to optimize_triton:**
-Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+**Step 7c. MCP optimization — pass error context to optimize_kernel:**
+Try `mcp__kernelgen-mcp__optimize_kernel` with the current kernel code and the
 `check_result` parameter containing the error traceback. This endpoint can fix
 memory access patterns, index calculations, and numerical issues.
 Replace the kernel code with the optimized output, re-run tests.
@@ -1192,7 +1192,7 @@ Detect the hosting platform from the remote URL:
   does not use autotune, do NOT introduce it — use a fixed BLOCK_SIZE matching the repo pattern.
 - **Follow alphabetical ordering** when adding entries to `__init__.py`, `__all__`, or config lists.
 - If accuracy tests fail, try to fix. If benchmark is slow, consider calling
-  `mcp__kernelgen-mcp__optimize_triton` to optimize.
+  `mcp__kernelgen-mcp__optimize_kernel` to optimize.
 - **Speedup formula**: `speedup = torch_latency / kernel_latency` (>1.0 means kernel is faster).
   If parsing fails, report raw output instead.
 - **Never modify unrelated files**. Keep the diff minimal and focused.

--- a/kernelgen-mcp/kernelgen-optimize-for-flaggems.md
+++ b/kernelgen-mcp/kernelgen-optimize-for-flaggems.md
@@ -1,0 +1,829 @@
+
+# FlagGems Operator Optimization & Integration Pipeline
+
+Supports three optimization modes: built-in operator in-place optimization (PATH A), external directory operator optimization & integration (PATH B), and experimental operator in-place optimization (PATH C).
+
+**Core Principle**: No new operator generation — only optimize existing operators. **Must record the initial speedup baseline before optimization** to quantify the optimization tool's effectiveness.
+
+## Prerequisites
+
+- `kernelgen-mcp` MCP server must be configured and running
+- Python environment with `torch`, `triton`, and `flag_gems` installed (environment and paths are dynamically detected in Step 0)
+
+## Arguments
+
+- `$ARGUMENTS` - Space-separated parameters:
+  1. **Operator name or source directory path** (required) — operator name (e.g., `relu`, `softmax`), external directory path, or experimental operator filename
+  2. Target speedup ratio (optional, default 1.2)
+  3. Maximum optimization iterations (optional, default 10)
+
+**Routing Rules**:
+- Input is an **existing directory path** → **PATH B** (external directory flow)
+- Input matches an existing file under `experimental_ops/` (e.g., `index_put_triton_nvidia_CC`) → **PATH C** (experimental operator in-place optimization)
+- Otherwise treated as a **built-in operator name**, check if `src/flag_gems/ops/{op_name}.py` exists:
+  - Exists → **PATH A** (built-in operator in-place optimization)
+  - Does not exist → Error `NOT_FOUND`
+
+Examples:
+- `/kernel-flagGems-optimize relu 1.2 3` — PATH A, built-in operator in-place optimization
+- `/kernel-flagGems-optimize /path/to/index_put_cc_nvidia` — PATH B, external directory flow
+- `/kernel-flagGems-optimize index_put_triton_nvidia_CC 1.4 5` — PATH C, experimental operator in-place optimization
+- `/kernel-flagGems-optimize nonexistent_op` — Error NOT_FOUND
+
+---
+
+## FlagGems Project Path Conventions
+
+All paths are relative to `${FLAGGEMS_ROOT}` (dynamically detected in Step 0):
+
+| Type | Relative Path |
+|------|--------------|
+| Built-in operators directory | `src/flag_gems/ops/` |
+| Experimental operators directory | `src/flag_gems/experimental_ops/` |
+| Registration file | `src/flag_gems/experimental_ops/__init__.py` |
+| Experimental unit tests | `experimental_tests/unit/` |
+| Experimental performance tests | `experimental_tests/performance/` |
+| Framework test directory | `tests/` |
+| Framework benchmark directory | `benchmark/` |
+
+## Naming Conventions (PATH B/C)
+
+| File Type | Naming Format | Example |
+|-----------|--------------|---------|
+| Triton operator | `{op_name}_triton_{gpu_name}_CC.py` | `index_put_triton_nvidia_CC.py` |
+| Unit test | `{op_name}_test_{gpu_name}_CC.py` | `index_put_test_nvidia_CC.py` |
+| Benchmark | `{op_name}_benchmark_{gpu_name}_CC.py` | `index_put_benchmark_nvidia_CC.py` |
+
+---
+
+## Workflow
+
+### PHASE 0: Environment Detection & Route Decision
+
+**Step 0.0: Dynamic Environment Detection** ⭐
+
+Two things need to be detected: **which Python environment has flag_gems installed**, and **the FlagGems project root directory**.
+
+**Step 0.0a: Try Current Python**
+
+```bash
+python -c "
+import torch, triton, flag_gems, os
+fg_file = flag_gems.__file__
+flaggems_root = os.path.abspath(os.path.join(os.path.dirname(fg_file), '..', '..'))
+print('FLAGGEMS_ROOT=' + flaggems_root)
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('flag_gems=' + flag_gems.__version__)
+print('device=' + str(flag_gems.device))
+"
+```
+
+- If successful → `PYTHON_CMD=python`, extract `FLAGGEMS_ROOT`, continue
+- If failed (import error) → proceed to Step 0.0b
+
+**Step 0.0b: Scan Conda Environments**
+
+When current Python lacks flag_gems, automatically scan conda environments:
+
+```bash
+for env in $(conda env list --json | python -c "import sys,json; print('\n'.join(json.load(sys.stdin)['envs']))"); do
+  name=$(basename "$env")
+  if conda run -n "$name" python -c "import flag_gems" 2>/dev/null; then
+    echo "FOUND_ENV=$name"
+    break
+  fi
+done
+```
+
+- Found → `PYTHON_CMD=conda run -n {found_env} python`
+- Not found → proceed to Step 0.0c to auto-create environment
+
+Re-execute the diagnostic script from 0.0a with the found `${PYTHON_CMD}` to extract `FLAGGEMS_ROOT`.
+
+**Step 0.0c: Auto-create Environment (only if both 0.0a and 0.0b fail)**
+
+No existing environment has flag_gems installed; automatically create a new environment and install all dependencies.
+
+**1. Locate FlagGems Project Root Directory**
+
+Search in the following order for a `pyproject.toml` containing `flag.gems` to confirm source location:
+
+```bash
+for candidate in "." "../FlagGems" "../../FlagGems"; do
+  if [ -f "$candidate/pyproject.toml" ] && grep -q "flag.gems" "$candidate/pyproject.toml" 2>/dev/null; then
+    echo "REPO_ROOT=$(cd "$candidate" && pwd)"
+    break
+  fi
+done
+```
+
+- Found → record `REPO_ROOT`
+- Not found → ask the user: `FlagGems project directory not found. Please provide the absolute path to the FlagGems repository root.`
+
+**2. Detect CUDA Version**
+
+```bash
+nvidia-smi | grep -oP "CUDA Version: \K[\d.]+"
+```
+
+If `nvidia-smi` is unavailable, try fallback:
+```bash
+nvcc --version 2>/dev/null | grep -oP "release \K[\d.]+"
+```
+
+Extract the CUDA major version (e.g., `11.8`, `12.1`, `12.6`) for selecting the torch wheel.
+If neither works, ask the user for the CUDA version.
+
+**3. Create Conda Environment**
+
+```bash
+ENV_NAME="flaggems_env"
+conda create -n ${ENV_NAME} python=3.10 -y
+```
+
+**4. Install PyTorch (select wheel based on CUDA version)**
+
+| CUDA Version | Install Command |
+|-------------|----------------|
+| 11.8 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu118` |
+| 12.1 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu121` |
+| 12.4+ | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu124` |
+| Uncertain | Ask the user to provide the correct torch install command |
+
+Verify CUDA availability after installation:
+```bash
+conda run -n ${ENV_NAME} python -c "import torch; print('cuda:', torch.version.cuda, 'available:', torch.cuda.is_available())"
+```
+
+- `torch.version.cuda` is `None` → CPU-only build, prompt user to reinstall with CUDA support
+- `torch.cuda.is_available()` is `False` → CUDA compiled but no GPU, warn user that tests will fail
+
+**5. Install Remaining Dependencies**
+
+```bash
+conda run -n ${ENV_NAME} pip install triton
+conda run -n ${ENV_NAME} pip install -e ${REPO_ROOT}
+conda run -n ${ENV_NAME} pip install pytest numpy scipy pyyaml packaging
+```
+
+If `pip install -e ${REPO_ROOT}` fails, check whether `${REPO_ROOT}` contains `pyproject.toml` or `setup.py`.
+If not, error: `ERROR: ${REPO_ROOT} is not a valid FlagGems project directory.`
+
+**6. Verify Installation**
+
+```bash
+conda run -n ${ENV_NAME} python -c "
+import torch, triton, flag_gems, os
+fg_file = flag_gems.__file__
+flaggems_root = os.path.abspath(os.path.join(os.path.dirname(fg_file), '..', '..'))
+print('FLAGGEMS_ROOT=' + flaggems_root)
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('flag_gems=' + flag_gems.__version__)
+print('device=' + str(flag_gems.device))
+"
+```
+
+- Success → `PYTHON_CMD=conda run -n ${ENV_NAME} python`, extract `FLAGGEMS_ROOT`
+- Failure → error and abort: `ERROR: Auto-environment creation failed. Please check the error message and configure manually.`
+
+**Step 0.0d: Record Environment Variables**
+
+Finalize two variables for all subsequent steps:
+- `PYTHON_CMD`: Full command to execute Python (e.g., `python` or `conda run -n xxx python`)
+- `FLAGGEMS_ROOT`: FlagGems project root directory
+
+All subsequent commands follow this pattern:
+- `cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest ...`
+- **Do not** hardcode conda environment names or absolute paths
+
+**Step 0.1: Parse Arguments**
+
+Parse from `$ARGUMENTS`:
+- `first_arg`: First argument (operator name or directory path)
+- `target_speedup`: Target speedup ratio (default 1.2)
+- `max_iterations`: Maximum optimization iterations (default 10)
+
+**Step 0.2: Route Decision**
+
+```
+IF first_arg is an existing directory:
+    → PATH B (external directory flow, jump to PHASE 0B)
+ELSE:
+    # Check if it's an existing operator under experimental_ops
+    # Supports with or without .py suffix
+    exp_name = first_arg (strip .py suffix)
+    IF file ${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_name}.py exists:
+        → PATH C (experimental operator in-place optimization, jump to PHASE 0C)
+    ELSE:
+        op_name = first_arg
+        IF file ${FLAGGEMS_ROOT}/src/flag_gems/ops/{op_name}.py exists:
+            → PATH A (built-in operator in-place optimization, jump to PHASE 0A)
+        ELSE:
+            → Error: "NOT_FOUND: '{first_arg}' is neither a valid directory nor found in experimental_ops/ or ops/"
+            → Abort
+```
+
+---
+
+# ═══════════════════════════════════════════════════════════
+# PATH A: Built-in Operator In-place Optimization
+# ═══════════════════════════════════════════════════════════
+
+### PHASE 0A: Locate & Backup
+
+**Step 0A.1: Locate Files**
+
+- Operator implementation: `${FLAGGEMS_ROOT}/src/flag_gems/ops/{op_name}.py`
+- Read the code, understand the implementation pattern (`@pointwise_dynamic` / raw `@triton.jit` / code generation / hybrid)
+
+**Step 0A.2: Verify pytest Mark Availability**
+
+Check correctness tests:
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest tests/ -m {op_name} --collect-only 2>&1
+```
+- If selected > 0 → `TEST_CMD_FLAG = -m`
+- If selected == 0 → fallback `-k {op_name}`
+- If both are 0 → error `NO_TEST`, abort
+
+Similarly check benchmarks:
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest benchmark/ -m {op_name} --collect-only 2>&1
+```
+- Found → `HAS_BENCHMARK = true`, record `BENCH_CMD_FLAG`
+- Not found → `HAS_BENCHMARK = false`, warn
+
+**Step 0A.3: Create Backup**
+
+```bash
+WORK_DIR="${FLAGGEMS_ROOT}/_optimize_backup/{op_name}_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$WORK_DIR"
+cp ${FLAGGEMS_ROOT}/src/flag_gems/ops/{op_name}.py "$WORK_DIR/{op_name}_original.py"
+```
+
+**Step 0A.4: Initialize Version Management**
+
+```
+safe_version_code = None
+safe_version_speedup = None
+best_version_code = None
+best_version_speedup = 0
+initial_speedup = None          # ⭐ Pre-optimization baseline speedup
+optimization_log = []
+```
+
+---
+
+### PHASE 2A: Correctness Verification + Initial Benchmark Baseline ⭐
+
+**Step 2A.1: Run Correctness Tests**
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest tests/ {TEST_CMD_FLAG} {op_name} -v 2>&1
+```
+
+- Pass → `safe_version_code` = current code
+- Fail → error `ORIGINAL_FAILED`, abort
+
+**Step 2A.2: Record Initial Benchmark Baseline** ⭐
+
+**Important**: Before any optimization, must run the benchmark first to get the initial speedup. This data serves as the baseline for evaluating optimization effectiveness.
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest benchmark/ {BENCH_CMD_FLAG} {op_name} -v -s 2>&1
+```
+
+Parse output, record:
+- `initial_speedup` = average speedup across all cases
+- `initial_benchmark_details` = detailed data for each case (input size, torch/triton time, speedup)
+- `best_version_speedup` = `initial_speedup`
+
+Output initial baseline summary:
+```
+┌─────────────────────────────────────────┐
+│ Initial Benchmark Baseline (Pre-opt)     │
+│ Operator: {op_name}                      │
+│ Average Speedup: {initial_speedup}x      │
+│ Min Speedup: {min_speedup}x              │
+│ Max Speedup: {max_speedup}x              │
+│ Target Speedup: {target_speedup}x        │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### PHASE 3A: Performance Optimization Loop (max {max_iterations} iterations)
+
+**Step 3A.1: Run Benchmark**
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest benchmark/ {BENCH_CMD_FLAG} {op_name} -v -s 2>&1
+```
+
+**Step 3A.2: Check Exit Conditions**
+
+- Average speedup >= target → proceed to PHASE 5A
+- Reached max_iterations → restore best_version_code, proceed to PHASE 5A
+- Current speedup > best_version_speedup → update best_version
+
+**Step 3A.3: Build Optimization Context Summary**
+
+```
+func_desc template:
+
+"Operator: {op_name}
+Function: {operator function description}
+Mode: FlagGems built-in operator (in-place optimization)
+
+== Initial Baseline ==
+Pre-optimization speedup: {initial_speedup}x
+
+== FlagGems Framework Info ==
+This operator uses FlagGems framework APIs; optimizations must maintain compatibility.
+
+== Current Optimization State ==
+Iteration: #{N} (max {max_iterations})
+Current speedup: {current_speedup}x (improvement over baseline: {improvement}%)
+Target speedup: {target_speedup}x
+
+== Benchmark Details ==
+| Input Size | PyTorch (ms) | Triton (ms) | Speedup |
+...
+
+== Optimization History ==
+...
+
+== Bottleneck Analysis ==
+..."
+```
+
+**Step 3A.4: Call MCP to Get Optimized Code**
+
+```
+MCP tool: mcp__kernelgen-mcp__optimize_kernel
+Parameters: kernel_name, triton_code, func_desc, device: nvidia
+```
+
+**Step 3A.5: Apply Optimized Code** → write back to ops file
+
+**Step 3A.6: Verify Correctness**
+- Pass → update safe_version, return to 3A.1
+- Fail → MCP fix (max 2 attempts), roll back if fix fails
+
+---
+
+### PHASE 5A: Final Verification
+
+Correctness + performance verification. Restore backup if failed.
+
+---
+
+### PHASE 6A: Generate Report
+
+The report must include:
+- **Initial Speedup (pre-optimization baseline)**
+- Final Speedup
+- Improvement = (final - initial) / initial * 100%
+
+```
+============================================================
+FLAGGEMS IN-PLACE OPTIMIZATION COMPLETE
+============================================================
+Operator: {op_name}
+Status: {SUCCESS | PARTIAL | FAILED}
+Initial Speedup (Baseline): {initial_speedup}x  ← pre-optimization
+Final Speedup:              {final_speedup}x     ← post-optimization
+Improvement:                +{improvement}%
+
+Modified File: src/flag_gems/ops/{op_name}.py
+Backup: _optimize_backup/{op_name}_{timestamp}/{op_name}_original.py
+============================================================
+```
+
+---
+
+# ═══════════════════════════════════════════════════════════
+# PATH B: External Directory Operator Optimization & Integration
+# ═══════════════════════════════════════════════════════════
+
+### PHASE 0B: Initialization
+
+**Step 0B.1: Parse Arguments**
+
+Parse `operator_path`, `target_speedup`, `max_iterations` from `$ARGUMENTS`.
+Extract `op_name`, `gpu_name`, `func_name` from directory/file names.
+
+**Step 0B.2: Create Working Copy**
+
+```bash
+WORK_DIR="<operator_path>_flaggems_optimize_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$WORK_DIR/iterations"
+cp <operator_path>/*.py "$WORK_DIR/"
+```
+
+**Step 0B.3: Initialize Version Management**
+
+```
+safe_version_code = None
+safe_version_speedup = None
+best_version_code = None
+best_version_speedup = 0
+initial_speedup = None          # ⭐ Pre-optimization baseline
+optimization_log = []
+```
+
+---
+
+### PHASE 1B: Pre-checks
+
+Verify required files (`*_triton.py`, `*_torch.py`, `test_*.py`, `benchmark_*.py`), read and understand source files.
+
+---
+
+### PHASE 2B: Correctness Verification + Initial Benchmark Baseline ⭐
+
+**Step 2B.1: Run Tests** (max 3 fix attempts)
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest test_*.py -v 2>&1
+```
+
+**Step 2B.2: Record Initial Benchmark Baseline** ⭐
+
+**Important**: After correctness passes and before optimization, must run the benchmark first to record the initial speedup.
+
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest benchmark_*.py -v -s 2>&1
+```
+
+Record `initial_speedup`, output initial baseline summary:
+```
+┌─────────────────────────────────────────┐
+│ Initial Benchmark Baseline (Pre-opt)     │
+│ Operator: {op_name}                      │
+│ Average Speedup: {initial_speedup}x      │
+│ Target Speedup: {target_speedup}x        │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### PHASE 3B: Performance Optimization Loop (max {max_iterations} iterations)
+
+Same optimization loop logic as PATH A, but operating on `*_triton.py` files in the working directory.
+
+---
+
+### PHASE 4B: FlagGems Integration
+
+**Step 4B.1**: Place Triton operator → `${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{op_name}_triton_{gpu_name}_CC.py`
+**Step 4B.2**: Register in `__init__.py` (check to avoid duplicates)
+**Step 4B.3**: Transform and place unit test → `${FLAGGEMS_ROOT}/experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py`
+**Step 4B.4**: Transform and place benchmark → `${FLAGGEMS_ROOT}/experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py`
+
+---
+
+### PHASE 5B: Verification Under FlagGems Framework
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py -v 2>&1
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py -v 2>&1
+```
+
+---
+
+### PHASE 6B: Generate Report
+
+The report must include comparison between the initial baseline speedup and the final speedup.
+
+```
+============================================================
+FLAGGEMS OPTIMIZATION & INTEGRATION COMPLETE
+============================================================
+Operator: {op_name} | GPU: {gpu_name}
+Status: {SUCCESS | PARTIAL | FAILED}
+Initial Speedup (Baseline): {initial_speedup}x  ← pre-optimization
+Final Speedup:              {final_speedup}x     ← post-optimization
+Improvement:                +{improvement}%
+
+FlagGems Files:
+  Op:        src/flag_gems/experimental_ops/{op_name}_triton_{gpu_name}_CC.py
+  Test:      experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py
+  Benchmark: experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py
+============================================================
+```
+
+---
+
+# ═══════════════════════════════════════════════════════════
+# PATH C: Experimental Operator In-place Optimization (NEW)
+# ═══════════════════════════════════════════════════════════
+
+Perform in-place optimization on existing experimental operators under `experimental_ops/`.
+Directly use existing tests in `experimental_tests/unit/` and `experimental_tests/performance/`.
+
+### PHASE 0C: Locate & Backup
+
+**Step 0C.1: Parse Operator Information**
+
+Parse from `first_arg` (e.g., `index_put_triton_nvidia_CC`):
+- `exp_file_name`: Full filename (without .py)
+- `op_name`: Base operator name (e.g., `index_put`) — extracted by removing `_triton_{gpu}_CC` from filename
+- `gpu_name`: GPU name (e.g., `nvidia`) — extracted from filename
+
+Corresponding file paths:
+- Operator file: `${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_file_name}.py`
+- Unit test: `${FLAGGEMS_ROOT}/experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py`
+- Performance test: `${FLAGGEMS_ROOT}/experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py`
+
+**Step 0C.2: Verify File Existence**
+
+Check if all three files exist:
+```bash
+ls ${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_file_name}.py
+ls ${FLAGGEMS_ROOT}/experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py
+ls ${FLAGGEMS_ROOT}/experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py
+```
+
+- Operator file missing → error `NOT_FOUND`
+- Test file missing → error `NO_TEST: Test file for {exp_file_name} not found`
+
+**Step 0C.3: Read and Understand Code**
+
+Read operator implementation, unit test, and benchmark code to understand:
+- Operator function and implementation approach
+- Kernel structure and potential optimization opportunities
+- Test case coverage
+
+**Step 0C.4: Create Backup**
+
+```bash
+WORK_DIR="${FLAGGEMS_ROOT}/_optimize_backup/{exp_file_name}_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$WORK_DIR"
+cp ${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_file_name}.py "$WORK_DIR/{exp_file_name}_original.py"
+```
+
+**Step 0C.5: Initialize Version Management**
+
+```
+safe_version_code = None
+safe_version_speedup = None
+best_version_code = None
+best_version_speedup = 0
+initial_speedup = None          # ⭐ Pre-optimization baseline
+optimization_log = []
+```
+
+---
+
+### PHASE 2C: Correctness Verification + Initial Benchmark Baseline ⭐
+
+**Step 2C.1: Run Correctness Tests**
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py -v 2>&1
+```
+
+- Pass → `safe_version_code` = current code
+- Fail → error `ORIGINAL_FAILED`, abort
+
+**Step 2C.2: Record Initial Benchmark Baseline** ⭐
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py -v 2>&1
+```
+
+Parse output, record:
+- `initial_speedup` = average speedup across all cases
+- `initial_benchmark_details` = detailed data for each case
+
+Output initial baseline summary:
+```
+┌─────────────────────────────────────────┐
+│ Initial Benchmark Baseline (Pre-opt)     │
+│ Operator: {exp_file_name}                │
+│ Average Speedup: {initial_speedup}x      │
+│ Min Speedup: {min_speedup}x              │
+│ Max Speedup: {max_speedup}x              │
+│ Target Speedup: {target_speedup}x        │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### PHASE 3C: Performance Optimization Loop (max {max_iterations} iterations)
+
+**Step 3C.1: Run Benchmark**
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py -v 2>&1
+```
+
+Parse output, record speedup. First run is same as `initial_speedup` (already recorded in 2C.2).
+
+**Step 3C.2: Check Exit Conditions**
+
+- Average speedup >= target → proceed to PHASE 5C
+- Reached max_iterations → restore best_version_code and write back to operator file, proceed to PHASE 5C
+- Current speedup > best_version_speedup → update best_version
+
+**Step 3C.3: Build Optimization Context Summary**
+
+```
+func_desc template:
+
+"Operator: {op_name} (experimental operator)
+File: experimental_ops/{exp_file_name}.py
+Function: {operator function description}
+
+== Initial Baseline ==
+Pre-optimization speedup: {initial_speedup}x
+
+== Current Optimization State ==
+Iteration: #{N} (max {max_iterations})
+Current speedup: {current_speedup}x (improvement over baseline: {improvement}%)
+Target speedup: {target_speedup}x
+Best historical speedup: {best_version_speedup}x
+
+== Benchmark Details ==
+| Test Case | PyTorch (ms) | Triton (ms) | Speedup |
+|-----------|-------------|-------------|---------|
+| ...       | ...         | ...         | ...     |
+
+== Optimization History ==
+- Iter {i}: {action}, Result: {status}, Speedup: {speedup}x
+...
+
+== Bottleneck Analysis ==
+{Analyze performance bottlenecks based on benchmark data}"
+```
+
+**Step 3C.4: Call MCP to Get Optimized Code**
+
+```
+MCP tool: mcp__kernelgen-mcp__optimize_kernel
+Parameters:
+- kernel_name: {op_name}
+- triton_code: Complete code of the current operator file
+- func_desc: Optimization context summary above
+- device: {gpu_name}
+```
+
+**Step 3C.5: Apply Optimized Code**
+
+**Directly write back** the MCP-returned code to `${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_file_name}.py`.
+
+**Important**: MCP-returned code should be reviewed by CC for quality. If the code has obvious issues, CC should optimize it independently.
+
+**Step 3C.6: Verify Correctness**
+
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py -v 2>&1
+```
+
+- Pass → update safe_version, return to 3C.1
+- Fail → MCP fix (max 2 attempts), roll back to safe_version if fix fails, continue to next iteration
+
+---
+
+### PHASE 5C: Final Verification
+
+**Step 5C.1: Correctness Verification**
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py -v 2>&1
+```
+
+**Step 5C.2: Performance Verification**
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pytest -s experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py -v 2>&1
+```
+
+**Step 5C.3: Handle Failure**
+
+If final verification fails:
+- Restore backup: `cp "$WORK_DIR/{exp_file_name}_original.py" ${FLAGGEMS_ROOT}/src/flag_gems/experimental_ops/{exp_file_name}.py`
+- Error `FAILED_FINAL_VERIFY`
+
+---
+
+### PHASE 6C: Generate Report
+
+**Step 6C.1: Generate `final_report.md`**
+
+```markdown
+# FlagGems Experimental Op Optimization Report
+
+## Summary
+| Metric | Value |
+|--------|-------|
+| Operator | {exp_file_name} |
+| GPU | {gpu_name} |
+| Initial Speedup (Baseline) | {initial_speedup}x |
+| Final Speedup | {final_speedup}x |
+| Best Speedup | {best_version_speedup}x |
+| Improvement | +{improvement}% |
+| Total Iterations | {N} |
+| Target Speedup | {target}x |
+| Status | {SUCCESS/PARTIAL/FAILED} |
+
+## Optimization History
+| Iter | Action | Correctness | Speedup | vs Baseline | Status |
+|------|--------|-------------|---------|-------------|--------|
+| 0    | Baseline | ✓         | {init}x | —           | baseline |
+| 1    | ...    | ...         | ...     | +{x}%       | ...    |
+| ...  | ...    | ...         | ...     | ...         | ...    |
+
+## Performance Comparison (Before vs After)
+| Test Case | Before (ms) | After (ms) | Before Speedup | After Speedup | Change |
+|-----------|-------------|------------|----------------|---------------|--------|
+| ...       | ...         | ...        | ...            | ...           | ...    |
+```
+
+**Step 6C.2: Output Summary**
+
+```
+============================================================
+FLAGGEMS EXPERIMENTAL OP OPTIMIZATION COMPLETE
+============================================================
+Operator: {exp_file_name}
+GPU: {gpu_name}
+Status: {SUCCESS | PARTIAL | FAILED}
+
+Performance:
+  Initial Speedup (Baseline): {initial_speedup}x  ← pre-optimization
+  Final Speedup:              {final_speedup}x     ← post-optimization
+  Improvement:                +{improvement}%
+
+Modified File:
+  src/flag_gems/experimental_ops/{exp_file_name}.py
+
+Backup:
+  _optimize_backup/{exp_file_name}_{timestamp}/{exp_file_name}_original.py
+
+Verify Commands:
+  cd ${FLAGGEMS_ROOT}
+  ${PYTHON_CMD} -m pytest -s experimental_tests/unit/{op_name}_test_{gpu_name}_CC.py -v
+  ${PYTHON_CMD} -m pytest -s experimental_tests/performance/{op_name}_benchmark_{gpu_name}_CC.py -v
+
+Restore Original:
+  cp _optimize_backup/{exp_file_name}_{timestamp}/{exp_file_name}_original.py src/flag_gems/experimental_ops/{exp_file_name}.py
+============================================================
+```
+
+---
+
+## MCP Tool Reference
+
+### mcp__kernelgen-mcp__optimize_kernel
+
+Optimize Triton kernel code. Can be used for performance optimization or error fixing.
+
+**Input Parameters:**
+```json
+{
+  "kernel_name": "Operator name",
+  "triton_code": "Current complete Triton code",
+  "func_desc": "Operator function description + optimization context summary",
+  "check_result": { "success": false, "error": "Error message" },
+  "device": "Target chip type"
+}
+```
+
+**Returns:**
+```json
+{
+  "triton_code": "Optimized/fixed complete code"
+}
+```
+
+**Important**: MCP-returned code should be reviewed by CC for quality. If the code has obvious issues (invalid syntax, unreasonable approach), CC should optimize it independently or make corrections based on the MCP result.
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| MCP service unavailable | Error: `ERROR: kernelgen-mcp MCP server not available.` |
+| Python environment missing dependencies | Error: `ERROR: Python environment missing required dependencies` |
+| Operator not found in any known location | Error: `NOT_FOUND` |
+| PATH A original code fails correctness | Error: `ORIGINAL_FAILED` |
+| PATH A no test cases | Error: `NO_TEST` |
+| PATH B source directory missing required files | Error with list of missing files |
+| PATH C no corresponding test file | Error: `NO_TEST` |
+| Correctness fails after 3 fix attempts | Error: `FAILED_CORRECTNESS` |
+| FlagGems verification fails | Error: `FAILED_INTEGRATION` (PATH B) or `FAILED_FINAL_VERIFY` (PATH A/C) |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| SUCCESS | Target speedup achieved and verification passed |
+| PARTIAL | Speedup improved but did not reach target, verification passed |
+| FAILED_CORRECTNESS | Correctness cannot pass during optimization phase |
+| FAILED_INTEGRATION | PATH B: Optimization succeeded but FlagGems integration verification failed |
+| FAILED_FINAL_VERIFY | PATH A/C: Final verification failed, original code restored |
+| FAILED_MCP | MCP service error |
+| NOT_FOUND | Operator not found in any known location |
+| ORIGINAL_FAILED | Original code fails correctness tests |
+| NO_TEST | No corresponding test cases found |

--- a/kernelgen-mcp/kernelgen-optimize-for-vllm.md
+++ b/kernelgen-mcp/kernelgen-optimize-for-vllm.md
@@ -1,0 +1,926 @@
+
+# vLLM Operator Optimization & Integration Pipeline
+
+## Automatic Execution Authorization
+
+**Important**: When the user invokes `/kernel-vllm-optimize`, all of the following operations are considered authorized — **no step-by-step user confirmation needed**:
+- Calling MCP tools to optimize operator code
+- Reading and editing vLLM project files (activation.py, test_activation.py, benchmark_activation.py)
+- Running pytest accuracy tests and benchmark performance tests in the conda environment
+- Automatically fixing code and re-running tests if tests fail
+
+The entire pipeline should execute to completion without pausing to ask the user, unless a severe error occurs that cannot be resolved automatically.
+
+---
+
+# vLLM Operator Optimization & Integration Pipeline
+
+Perform MCP iterative optimization on existing Triton operator code, then automatically integrate into the vLLM project (register CustomOp, add accuracy tests, add performance benchmarks).
+
+**Core Principle**: No new operator generation — only optimize existing operators, then integrate into vLLM. **Must record the initial speedup baseline before optimization** to quantify the optimization effectiveness.
+
+## Prerequisites
+
+- `kernelgen-mcp` MCP server must be configured and running
+- Python environment with `torch` and `triton` installed (environment and paths are dynamically detected in PHASE 0)
+- vLLM project must be installed in editable mode (`pip install -e .`) so that modified operator code takes effect immediately
+- vLLM project root directory (dynamically detected in PHASE 0)
+
+## Arguments
+
+- `$ARGUMENTS` - Space-separated parameters:
+  1. Operator source directory path (required) — contains existing `*_triton.py`, `*_torch.py`, `test_*.py`, `benchmark_*.py`
+  2. Target speedup ratio (optional, default 1.2)
+  3. Maximum optimization iterations (optional, default 10)
+
+Automatically extracted from directory/file names:
+- **Operator name**: Extracted from `*_triton.py` filename (e.g., `index_put_triton.py` → `index_put`)
+- **GPU name**: Extracted from directory name (e.g., `index_put_cc_nvidia` → `nvidia`), defaults to `nvidia` if not found
+- **Operator type**: Auto-inferred from name (contains `_and_mul` → `act_and_mul`, otherwise → `act`), user can specify explicitly
+
+Examples:
+- `/kernel-vllm-optimize /path/to/relu_cc_nvidia` — Default target 1.2x, max 10 iterations
+- `/kernel-vllm-optimize /path/to/softmax_cc_nvidia 1.5` — Target 1.5x, max 10 iterations
+- `/kernel-vllm-optimize /path/to/silu_and_mul_cc_huawei 1.3 20` — Target 1.3x, max 20 iterations
+
+---
+
+## vLLM Key Paths
+
+All paths relative to `${VLLM_ROOT}` (dynamically detected in PHASE 0):
+
+| Type | Relative Path |
+|------|--------------|
+| Operator definition (kernel + wrapper + CustomOp + Registry) | `vllm/model_executor/layers/activation.py` |
+| CustomOp base class | `vllm/model_executor/custom_op.py` |
+| Accuracy tests | `tests/kernels/core/test_activation.py` |
+| Performance benchmark | `benchmarks/kernels/benchmark_activation.py` |
+
+## Naming Conventions
+
+Using `relu` + `huawei` as an example:
+
+| Entity | Naming Format | Example |
+|--------|--------------|---------|
+| Full operator name | `{base_op_name}_{gpu}` | `relu_huawei` |
+| Triton kernel | `_{full_op_name}_kernel` | `_relu_huawei_kernel` |
+| Triton wrapper | `{full_op_name}_triton` | `relu_huawei_triton` |
+| CustomOp registration name | `{full_op_name}` | `relu_huawei` |
+| CustomOp class name | `{OpCamelCase}{GpuCamelCase}` | `ReluHuawei` |
+| Benchmark func-name | `{full_op_name}` | `relu_huawei` |
+
+**Class name conversion rules**: Base operator name and GPU identifier each capitalized and concatenated.
+- `relu` + `nvidia` → `ReluNvidia`
+- `gelu_new` + `huawei` → `GeluNewHuawei`
+
+## Operator Type Determination Rules
+
+- Names containing `_and_mul` suffix → `act_and_mul` type
+- Other standalone activation functions → `act` type
+- User can specify explicitly; explicit specification takes priority
+
+---
+
+## Workflow
+
+### PHASE 0: Environment Detection & Initialization
+
+**Step 0.0: Dynamic Environment Detection** ⭐
+
+Two things need to be detected: **which Python environment has torch + triton installed**, and **the vLLM project root directory**.
+
+**Step 0.0a: Try Current Python**
+
+```bash
+python -c "
+import torch, triton, os
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('cuda=' + str(torch.version.cuda))
+print('cuda_available=' + str(torch.cuda.is_available()))
+"
+```
+
+- If successful → `PYTHON_CMD=python`, continue
+- If failed (import error) → proceed to Step 0.0b
+
+**Step 0.0b: Scan Conda Environments**
+
+When current Python lacks torch/triton, automatically scan conda environments:
+
+```bash
+for env in $(conda env list --json | python -c "import sys,json; print('\n'.join(json.load(sys.stdin)['envs']))"); do
+  name=$(basename "$env")
+  if conda run -n "$name" python -c "import torch, triton" 2>/dev/null; then
+    echo "FOUND_ENV=$name"
+    break
+  fi
+done
+```
+
+- Found → `PYTHON_CMD=conda run -n {found_env} python`
+- Not found → proceed to Step 0.0c
+
+Re-execute the diagnostic script from 0.0a with the found `${PYTHON_CMD}` to verify the environment.
+
+**Step 0.0c: Auto-create Environment (only if both 0.0a and 0.0b fail)**
+
+No existing environment has torch + triton installed; automatically create a new environment.
+
+**1. Detect CUDA Version**
+
+```bash
+nvidia-smi | grep -oP "CUDA Version: \K[\d.]+"
+```
+
+If `nvidia-smi` is unavailable, try fallback:
+```bash
+nvcc --version 2>/dev/null | grep -oP "release \K[\d.]+"
+```
+
+**2. Create Conda Environment**
+
+```bash
+ENV_NAME="vllm_opt_env"
+conda create -n ${ENV_NAME} python=3.10 -y
+```
+
+**3. Install PyTorch (select wheel based on CUDA version)**
+
+| CUDA Version | Install Command |
+|-------------|----------------|
+| 11.8 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu118` |
+| 12.1 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu121` |
+| 12.4+ | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu124` |
+| Uncertain | Ask the user to provide the correct torch install command |
+
+**4. Install Remaining Dependencies**
+
+```bash
+conda run -n ${ENV_NAME} pip install triton pytest numpy
+```
+
+**Note**: vLLM editable installation is handled in Step 0.0e (requires locating VLLM_ROOT first).
+
+**5. Verify Installation**
+
+```bash
+conda run -n ${ENV_NAME} python -c "
+import torch, triton
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('cuda=' + str(torch.version.cuda))
+print('cuda_available=' + str(torch.cuda.is_available()))
+"
+```
+
+- Success → `PYTHON_CMD=conda run -n ${ENV_NAME} python`
+- Failure → error and abort: `ERROR: Auto-environment creation failed. Please check the error message and configure manually.`
+
+**Step 0.0d: Locate vLLM Project Root Directory**
+
+Search for directories containing the `vllm` project identifier:
+
+```bash
+for candidate in "." "../vllm" "../../vllm" "/share/project/cws/vllm"; do
+  if [ -f "$candidate/pyproject.toml" ] && grep -q 'name = "vllm"' "$candidate/pyproject.toml" 2>/dev/null; then
+    echo "VLLM_ROOT=$(cd "$candidate" && pwd)"
+    break
+  fi
+done
+```
+
+- Found → record `VLLM_ROOT`
+- Not found → ask the user: `vLLM project directory not found. Please provide the absolute path to the vLLM repository root.`
+
+Verify key files exist:
+```bash
+ls ${VLLM_ROOT}/vllm/model_executor/layers/activation.py
+ls ${VLLM_ROOT}/vllm/model_executor/custom_op.py
+```
+
+**Step 0.0e: Ensure vLLM is Installed in Editable Mode** ⭐
+
+vLLM tests use `from vllm.model_executor.layers.activation import ...`, so the vllm package must be importable and modified code must take effect immediately.
+
+**1. Check if vllm is Already Installed**
+
+```bash
+${PYTHON_CMD} -c "
+import vllm, os
+vllm_init = os.path.abspath(vllm.__file__)
+print('VLLM_INSTALLED=' + vllm_init)
+"
+```
+
+- Success and `vllm.__file__` points to `${VLLM_ROOT}/vllm/__init__.py` → correctly installed (editable mode), continue
+- Success but points to another path → warning: `WARNING: vllm install path ({path}) does not match project directory (${VLLM_ROOT}). Modifications may not take effect. Consider reinstalling.`
+- Failure (import error) → proceed to step 2 for installation
+
+**2. Editable Install vLLM**
+
+vLLM has C++ extensions; full compilation is slow. Try pure Python installation first (skip C extension compilation):
+
+```bash
+cd ${VLLM_ROOT} && VLLM_USE_PRECOMPILED=1 ${PYTHON_CMD} -m pip install -e . 2>&1
+```
+
+If `VLLM_USE_PRECOMPILED=1` fails (no precompiled wheel), try without C extension compilation:
+
+```bash
+cd ${VLLM_ROOT} && MAX_JOBS=1 ${PYTHON_CMD} -m pip install -e . --no-build-isolation 2>&1
+```
+
+If still fails (missing build tools), **fallback to PYTHONPATH approach**:
+
+```bash
+export PYTHONPATH="${VLLM_ROOT}:${PYTHONPATH}"
+```
+
+And verify import works:
+```bash
+${PYTHON_CMD} -c "import vllm; print('vllm imported from:', vllm.__file__)"
+```
+
+If the PYTHONPATH approach also fails → error: `ERROR: Cannot install or import vllm. Please manually run 'cd ${VLLM_ROOT} && pip install -e .'`
+
+**Step 0.0f: Record Environment Variables**
+
+Finalize two variables for all subsequent steps:
+- `PYTHON_CMD`: Full command to execute Python (e.g., `python` or `conda run -n xxx python`)
+- `VLLM_ROOT`: vLLM project root directory
+
+All subsequent commands follow this pattern:
+- `cd ${VLLM_ROOT} && ${PYTHON_CMD} -m pytest ...`
+- **Do not** hardcode conda environment names or absolute paths
+
+**Step 0.1: Parse Arguments**
+
+Parse from `$ARGUMENTS`:
+- `operator_path`: Operator source directory path
+- `target_speedup`: Target speedup ratio (default 1.2)
+- `max_iterations`: Maximum optimization iterations (default 10)
+
+Extract from directory/file names:
+- `op_name`: Operator name
+- `gpu_name`: GPU name (default `nvidia`)
+- `full_op_name`: `{op_name}_{gpu_name}`
+- `class_name`: CamelCase version of `{full_op_name}`
+- `op_type`: `act` or `act_and_mul`
+- `func_name`: Exported Python wrapper function name from the Triton file
+
+**Step 0.2: Create Working Copy**
+
+Copy source directory files to a working directory for optimization, avoiding pollution of original files:
+```bash
+WORK_DIR="<operator_path>_vllm_optimize_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$WORK_DIR/iterations"
+cp <operator_path>/*_triton.py <operator_path>/*_torch.py <operator_path>/test_*.py <operator_path>/benchmark_*.py "$WORK_DIR/"
+# Also try copying *_test.py and *_benchmark.py formats
+cp <operator_path>/*_test.py <operator_path>/*_benchmark.py "$WORK_DIR/" 2>/dev/null || true
+```
+
+**Step 0.3: Initialize Version Management & Optimization Log**
+
+Maintain the following runtime state (tracked in memory, with file backups):
+
+```
+safe_version_code = None       # Latest Triton code that passed correctness tests
+safe_version_speedup = None    # Speedup of the safe version
+best_version_code = None       # Code with the best historical speedup
+best_version_speedup = 0       # Best historical speedup
+initial_speedup = None         # ⭐ Pre-optimization baseline speedup
+
+optimization_log = []
+# Each record: { "iteration", "action", "correctness", "speedup", "status" }
+```
+
+**Step 0.4: Version File Backup Rules**
+
+Whenever safe_version is updated, also back up the code to `$WORK_DIR/iterations/`:
+```bash
+cp *_triton.py "$WORK_DIR/iterations/triton_iter_{N}_safe.py"
+```
+
+---
+
+### PHASE 1: Pre-checks
+
+**Step 1.1: Verify Working Directory Structure**
+
+Check required files in `WORK_DIR`:
+- `*_triton.py` — Triton implementation (required)
+- `*_torch.py` — PyTorch baseline (required)
+- `test_*.py` or `*_test.py` — Test file (required, abort if missing)
+- `benchmark_*.py` or `*_benchmark.py` — Performance test (required)
+
+**Step 1.2: Read and Analyze Source Files**
+
+Read all source files, focusing on:
+
+**1.2a: Triton Code Analysis**
+- Identify kernel functions and wrapper functions
+- Check for known code defects (e.g., function name reference errors, undefined variables)
+- Record current BLOCK_SIZE, num_warps, and other configurations
+- Determine kernel pattern (Pattern A: Pointwise 1D grid / Pattern B: Row-based 2D grid)
+
+**1.2b: Triton Compatibility Pre-check** ⭐
+
+Before starting optimization, identify the following Triton limitations and record as `dtype_constraints`:
+
+| Feature | Supported dtypes | Unsupported dtypes |
+|---------|-----------------|-------------------|
+| `tl.atomic_add` | float32, float16, int32 | **bfloat16**, int8, int16, int64, float64 |
+| `tl.atomic_max/min` | int32, int64 | All floating-point types |
+| `tl.atomic_cas` | int32, int64 | Floating-point types |
+
+**1.2c: Benchmark Review** ⭐
+
+**Must review benchmark code before running benchmarks**, checking for these issues:
+
+1. **Fairness check**: Are PyTorch baseline and Triton implementation measured on the same device (GPU)?
+   - Check for `.cpu()` calls causing PyTorch to be measured on CPU while Triton runs on GPU
+   - If found, **fix the benchmark immediately** so both use `triton.testing.do_bench` on GPU
+2. **Data scale check**: Are the tensor sizes large enough?
+   - Too small sizes are dominated by kernel launch overhead and can't show Triton's advantage
+   - Recommend at least 1K~16K level update counts
+3. **Measurement method check**: Is `triton.testing.do_bench` or `torch.cuda.Event` properly used for GPU timing?
+   - `time.perf_counter()` is only suitable for CPU timing, not GPU kernel timing
+4. **Warmup check**: Are there enough warmup iterations (recommend ≥10)?
+
+If issues are found, **fix them before PHASE 2** and record the fixes.
+
+---
+
+### PHASE 2: Correctness Verification + Initial Benchmark Baseline (max 3 fix iterations)
+
+**Step 2.1: Run Tests**
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest test_*.py *_test.py -v 2>&1
+```
+
+**Step 2.2: Tests Pass → Save as safe_version**
+
+Back up file to `$WORK_DIR/iterations/triton_iter_0_safe.py`.
+
+**Step 2.3: Record Initial Benchmark Baseline** ⭐
+
+**Important**: After correctness passes and before optimization, must run the benchmark first to record the initial speedup.
+
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest benchmark_*.py *_benchmark.py -v -s 2>&1
+```
+
+Parse output, record:
+- `initial_speedup` = average speedup across all cases
+- `safe_version_speedup` = `initial_speedup`
+- `best_version_speedup` = `initial_speedup`
+
+Output initial baseline summary:
+```
+┌─────────────────────────────────────────┐
+│ Initial Benchmark Baseline (Pre-opt)     │
+│ Operator: {op_name}                      │
+│ Average Speedup: {initial_speedup}x      │
+│ Target Speedup: {target_speedup}x        │
+└─────────────────────────────────────────┘
+```
+
+**Step 2.4: Tests Fail → Call MCP to Fix**
+
+Call `mcp__kernelgen-mcp__optimize_kernel` with `check_result` to fix:
+```
+Parameters:
+- kernel_name: Operator name
+- triton_code: Complete code of the current Triton implementation
+- check_result: { "success": false, "error": "Error stack trace", "test_case": "Failed test case" }
+```
+
+Max 3 fix attempts; if still failing, abort with error `FAILED_CORRECTNESS`.
+
+---
+
+### PHASE 3: Performance Optimization Loop (max {max_iterations} iterations)
+
+**Step 3.1: Run Benchmark**
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest benchmark_*.py *_benchmark.py -v -s 2>&1
+```
+
+Parse output, extract PyTorch time, Triton time, and speedup for each input size.
+Record current overall speedup, update `safe_version_speedup`.
+
+**Step 3.2: Check Exit Conditions**
+
+- Average speedup ≥ target → update `best_version`, proceed to **PHASE 4**
+- Reached `max_iterations` → restore `best_version_code`, proceed to **PHASE 4**
+- Current speedup > `best_version_speedup` → update best_version
+
+**Step 3.3: Profiling Analysis (execute on first iteration and key iterations)** ⭐
+
+Before the first optimization, and when speedup shows no improvement for 2 consecutive iterations, perform profiling analysis.
+
+Use `torch.cuda.Event` timing to measure each phase of the wrapper:
+1. **Index preprocessing time** (broadcast, flat_idx calculation, etc.)
+2. **Data preparation time** (clone, contiguous, dtype conversions, etc.)
+3. **Kernel execution time** (pure Triton kernel portion)
+4. **Post-processing time** (dtype back-conversion, etc.)
+
+Record as `profiling_breakdown`, passed to MCP in Step 3.4.
+
+**Step 3.4: Build Optimization Context Summary** ⭐
+
+Before calling MCP, **must** build an optimization context summary and pass it to MCP via the `func_desc` parameter:
+
+```
+func_desc template:
+
+"Operator: {op_name}
+Function: {operator function description}
+
+== Current Optimization State ==
+Iteration: #{N} (max {max_iterations})
+Current speedup: {current_speedup}x
+Target speedup: {target_speedup}x
+Best historical speedup: {best_version_speedup}x
+
+== Triton Compatibility Constraints ==
+{dtype_constraints content, e.g.: bf16 doesn't support atomic_add, needs upcast to float32}
+
+== Profiling Analysis (if available) ==
+| Phase | Time (ms) | Proportion |
+|-------|-----------|------------|
+| Index Prep | {x}ms | {y}% |
+| Data Prep | {x}ms | {y}% |
+| Kernel Exec | {x}ms | {y}% |
+| Post-process | {x}ms | {y}% |
+Bottleneck: {bottleneck}
+
+== Benchmark Details ==
+| Input Size | PyTorch (ms) | Triton (ms) | Speedup |
+|------------|-------------|-------------|---------|
+| {size_1}   | {torch_ms}  | {triton_ms} | {spd}x  |
+
+== Optimization History ==
+- Iter {i}: {action}, Result: {status}, Speedup: {speedup}x
+
+== Bottleneck Analysis ==
+{Analyze performance bottlenecks based on benchmark and profiling data}
+
+== Optimization Constraints (Important!) ==
+- Do not significantly increase kernel complexity or parameter count
+- If bottleneck is in wrapper rather than kernel, focus on optimizing wrapper logic
+- Must follow the Triton compatibility constraints above
+- Optimized code must maintain the same wrapper interface (input/output signatures unchanged)"
+```
+
+**Step 3.5: Call MCP to Get Optimized Code**
+
+```
+Use MCP tool: mcp__kernelgen-mcp__optimize_kernel
+
+Parameters:
+- kernel_name: Operator name
+- triton_code: Complete code of current safe_version
+- func_desc: Optimization context summary built in Step 3.4
+- device: GPU type (nvidia / haiguang / moore / tianshu / huawei)
+```
+
+**Step 3.6: MCP Result Usability Check** ⭐
+
+Before writing to file, **must first check if the MCP-returned code is usable**:
+
+1. **Basic syntax check**: Is the code valid Python? Does it contain complete kernel and wrapper functions?
+2. **Complexity check**: If the new code's kernel parameter count increases more than 3x, or line count increases more than 5x, consider it over-complex and skip this iteration
+3. **Interface compatibility check**: Is the wrapper function's input/output signature consistent with the original version?
+4. **Known defect check**: Does it reference undefined variables? Does it use operations marked as unsupported in `dtype_constraints`?
+
+If the check fails:
+- Log entry: `{"status": "skipped", "action": "MCP returned unusable code: {reason}"}`
+- **Do not write to file**, proceed directly to next iteration
+- In the next iteration, explain in func_desc why the previous iteration was skipped
+
+**Step 3.7: Apply Optimized Code**
+
+Write the MCP-returned `triton_code` to the `*_triton.py` file.
+Back up the pre-optimization `safe_version_code` (memory + file).
+
+**Important**: If the MCP-returned code is obviously low quality (invalid syntax, unreasonable approach), CC should make independent judgments and manual optimizations rather than blindly adopting the MCP result.
+
+**Step 3.8: Verify Correctness**
+```bash
+cd $WORK_DIR && ${PYTHON_CMD} -m pytest test_*.py *_test.py -v 2>&1
+```
+
+**Case A: Tests Pass**
+- Update `safe_version_code`, back up to iterations/, return to Step 3.1
+
+**Case B: Tests Fail → Call MCP to Fix (max 2 attempts)**
+```
+Parameters:
+- kernel_name: Operator name
+- triton_code: Current failing code
+- func_desc: Optimization context + "Note: The last optimization caused correctness failure. Please fix correctness while maintaining performance optimizations. Triton compatibility constraints: {dtype_constraints}"
+- check_result: { "success": false, "error": "Error stack trace", "test_case": "Failed test case" }
+```
+
+- Fix successful → status="fixed_then_applied", update safe_version, return to Step 3.1
+- Fix failed (both attempts failed) → **Roll back** to safe_version (restore from backup file), status="rolled_back", continue to next iteration
+
+---
+
+### PHASE 4: vLLM Integration
+
+After optimization is complete, integrate the best version of the code into the vLLM project.
+
+#### Step 4.1: Extract and Adapt Triton Kernel + Wrapper
+
+Extract kernel and wrapper from `best_version_code`, rename according to vLLM naming conventions:
+
+- kernel: `_{full_op_name}_kernel` (e.g., `_relu_nvidia_kernel`)
+- wrapper: `{full_op_name}_triton` (e.g., `relu_nvidia_triton`)
+
+**Wrapper signature adaptation**:
+- In vLLM, wrapper signatures are unified as `(output: torch.Tensor, input: torch.Tensor)` (may have extra parameters like `limit`)
+- If the original wrapper signature differs (e.g., return-value style `def xxx(input) -> output`), transform to inplace style
+
+**Must add multi-GPU safety wrapper**:
+```python
+with torch.cuda.device(input.device):
+    # kernel launch
+```
+
+#### Step 4.2: Add Code to activation.py
+
+**File**: `${VLLM_ROOT}/vllm/model_executor/layers/activation.py`
+
+First read the current file content, then add at appropriate positions:
+
+**4.2a: Add Triton Kernel + Wrapper**
+
+Add near existing Triton kernel functions in the file. Choose wrapper implementation based on kernel pattern:
+
+**Pattern A — Pointwise (`act` type common)**:
+```python
+@triton.jit
+def _{full_op_name}_kernel(
+    input_ptr, output_ptr, n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(input_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    y = ...  # Extract kernel logic from best_version_code
+    tl.store(output_ptr + offsets, y, mask=mask)
+
+def {full_op_name}_triton(output: torch.Tensor, input: torch.Tensor):
+    input_contig = input.contiguous()
+    n_elements = input_contig.numel()
+    def grid(meta):
+        return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch.cuda.device(input.device):
+        _{full_op_name}_kernel[grid](input_contig, output, n_elements, BLOCK_SIZE=1024)
+```
+
+**Pattern B — Row-based (`act_and_mul` type common)**:
+```python
+@triton.jit
+def _{full_op_name}_kernel(
+    o_ptr, o_stride, x_ptr, x_stride,
+    d: tl.constexpr, BLOCK_SIZE: tl.constexpr,
+) -> None:
+    i = tl.program_id(axis=0).to(tl.int64)
+    j = tl.program_id(axis=1)
+    o_row_ptr = o_ptr + o_stride * i
+    x_row_ptr = x_ptr + x_stride * i
+    offsets = j * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < d
+    gate = tl.load(x_row_ptr + offsets, mask=mask).to(tl.float32)
+    up = tl.load(x_row_ptr + offsets + d, mask=mask).to(tl.float32)
+    result = ...  # Extract kernel logic from best_version_code
+    result = result.to(x_ptr.dtype.element_ty)
+    tl.store(o_row_ptr + offsets, result, mask=mask)
+
+def {full_op_name}_triton(output: torch.Tensor, input: torch.Tensor):
+    b, n = input.shape
+    assert input.ndim == 2
+    assert n % 2 == 0
+    d = n // 2
+    def grid(meta):
+        return (b, triton.cdiv(d, meta["BLOCK_SIZE"]))
+    with torch.cuda.device(input.device):
+        _{full_op_name}_kernel[grid](
+            output, output.stride(0),
+            input, input.stride(0),
+            d=d, BLOCK_SIZE=1024,
+        )
+```
+
+**Notes**:
+- Use the actual kernel logic from best_version_code — the above are structural templates only
+- MCP-optimized kernels may have different BLOCK_SIZE or additional parameters; preserve them
+- If the kernel has extra constexpr parameters (e.g., `limit`), the wrapper must also receive and pass them
+
+**4.2b: Add CustomOp Class**
+
+Add at the end of existing CustomOp classes (before the Registry dictionary):
+
+**act type (reference ReluMCP)**:
+```python
+@CustomOp.register("{full_op_name}")
+class {class_name}(CustomOp):
+    """Generated by kernelgen-mcp for {gpu_name} GPU. Optimized via MCP."""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        # Implement based on PyTorch logic from *_torch.py
+        return ...
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        {full_op_name}_triton(out, x)
+        return out
+```
+
+**act_and_mul type (reference SwigluStepAndMul)**:
+```python
+@CustomOp.register("{full_op_name}")
+class {class_name}(CustomOp):
+    """Generated by kernelgen-mcp for {gpu_name} GPU. Optimized via MCP."""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        # Implement based on PyTorch logic from *_torch.py
+        gate, up = x[..., :d], x[..., d:]
+        return ...
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        output_shape = x.shape[:-1] + (d,)
+        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+        {full_op_name}_triton(out, x)
+        return out
+```
+
+**With constructor parameters**: Reference `SwigluStepAndMul`'s `limit` parameter pattern, adding `__init__` parameters and `extra_repr`.
+
+**4.2c: Register in Registry**
+
+- **act type**: Add to `_ACTIVATION_REGISTRY` LazyDict:
+  ```python
+  "{full_op_name}": lambda: {class_name}(),
+  ```
+- **act_and_mul type**: Add to `_ACTIVATION_AND_MUL_REGISTRY` LazyDict:
+  ```python
+  "{full_op_name}": lambda: {class_name}(),
+  ```
+
+**Note**: Read the current file content first, check for existing registrations with the same name (avoid duplicates), and append to existing entries.
+
+#### Step 4.3: Add Accuracy Tests
+
+**File**: `${VLLM_ROOT}/tests/kernels/core/test_activation.py`
+
+First read the current file content, then:
+
+**4.3a: Add Import**
+```python
+from vllm.model_executor.layers.activation import (
+    ...,
+    {class_name},
+    {full_op_name}_triton,
+)
+```
+
+**4.3b: Add Tests Based on Operator Type**
+
+**`act` type — 1 modification**:
+Append to the `@pytest.mark.parametrize("activation", [...])` list in `test_activation`:
+```python
+pytest.param(({class_name}, {full_op_name}_triton), id="{class_name}"),
+```
+No other modifications needed; `test_activation` automatically determines whether to skip opcheck via `hasattr(fn, '_schema')`.
+
+**`act_and_mul` type — 4 modifications**:
+
+1. **parametrize list**: Append `"{full_op_name}"`
+2. **elif branch**: Add
+   ```python
+   elif activation == "{full_op_name}":
+       layer = {class_name}()
+       fn = {full_op_name}_triton
+   ```
+3. **Precision tolerance list**: Add `"{full_op_name}"` to the relaxed tolerance `if activation in [...]`
+4. **opcheck exclusion**: Add `and activation != "{full_op_name}"` to the exclusion condition
+
+#### Step 4.4: Add Performance Benchmark
+
+**File**: `${VLLM_ROOT}/benchmarks/kernels/benchmark_activation.py`
+
+First read the current file content, then:
+
+**4.4a**: Add `"{full_op_name}"` to the `--func-name` `choices` list
+
+**4.4b**: In most cases, no function body modification needed (the existing `else: layer = op_registry[func_name]()` default branch handles it automatically). Add elif branch when constructor parameters are needed.
+
+---
+
+### PHASE 5: Verification Under vLLM Framework
+
+**Step 5.1: Run Accuracy Tests** (only run current operator's cases)
+```bash
+cd ${VLLM_ROOT} && ${PYTHON_CMD} -m pytest tests/kernels/core/test_activation.py -v -k "{class_name}"
+```
+
+**Step 5.2: Run Performance Benchmark**
+```bash
+cd ${VLLM_ROOT} && CUDA_VISIBLE_DEVICES=0 ${PYTHON_CMD} benchmarks/kernels/benchmark_activation.py --func-name {full_op_name} --dtype bfloat16
+```
+
+**Step 5.3: Handle Failure**
+
+If tests fail under the vLLM framework:
+- Check if import paths are correct
+- Check if CustomOp registration name matches the Registry
+- Check if wrapper signature is in `(output, input)` format
+- Check if `cuda:1` tests fail due to missing `torch.cuda.device(input.device)`
+- Check if opcheck exclusion is correct (Triton ops don't support opcheck)
+- Fix and re-run tests, max 3 fix attempts
+- If still failing, report `FAILED_INTEGRATION`, preserve files for manual debugging
+
+---
+
+### PHASE 6: Generate Report
+
+**Step 6.1: Generate `final_report.md`**
+
+Save to working directory `$WORK_DIR/final_report.md`:
+
+```markdown
+# vLLM Kernel Optimization & Integration Report
+
+## Summary
+| Metric | Value |
+|--------|-------|
+| Operator | {op_name} |
+| GPU | {gpu_name} |
+| Op Type | {op_type} |
+| Initial Speedup (Baseline) | {initial_speedup}x |
+| Final Speedup | {final}x |
+| Best Speedup | {best_version_speedup}x |
+| Improvement | +{improvement}% |
+| Total Iterations | {N} |
+| Target Speedup | {target}x |
+| Status | {SUCCESS/PARTIAL/FAILED} |
+
+## Optimization History
+| Iter | Action | Correctness | Speedup | Status |
+|------|--------|-------------|---------|--------|
+| ...  | ...    | ...         | ...     | ...    |
+
+## vLLM Integration
+| Component | Location |
+|-----------|----------|
+| Kernel + Wrapper + CustomOp + Registry | vllm/model_executor/layers/activation.py |
+| Accuracy Test | tests/kernels/core/test_activation.py |
+| Benchmark | benchmarks/kernels/benchmark_activation.py |
+
+## Performance (Best Version)
+| Input Size | PyTorch (ms) | Triton (ms) | Speedup |
+|------------|--------------|-------------|---------|
+| ...        | ...          | ...         | ...     |
+
+## Profiling Breakdown (if available)
+| Phase | Time (ms) | Percentage |
+|-------|-----------|------------|
+| ...   | ...       | ...        |
+```
+
+**Step 6.2: Output Summary**
+
+```
+============================================================
+VLLM OPTIMIZATION & INTEGRATION COMPLETE
+============================================================
+Operator: {op_name}
+GPU: {gpu_name}
+Type: {op_type}
+Status: {SUCCESS | PARTIAL | FAILED}
+Initial Speedup (Baseline): {initial_speedup}x  ← pre-optimization
+Final Speedup:              {final_speedup}x     ← post-optimization
+Improvement:                +{improvement}%
+
+vLLM Files (under ${VLLM_ROOT}/):
+  Activation: vllm/model_executor/layers/activation.py (kernel + wrapper + CustomOp + Registry)
+  Test:       tests/kernels/core/test_activation.py
+  Benchmark:  benchmarks/kernels/benchmark_activation.py
+
+Verify Commands:
+  cd ${VLLM_ROOT}
+  ${PYTHON_CMD} -m pytest tests/kernels/core/test_activation.py -v -k "{class_name}"
+  CUDA_VISIBLE_DEVICES=0 ${PYTHON_CMD} benchmarks/kernels/benchmark_activation.py --func-name {full_op_name} --dtype bfloat16
+============================================================
+```
+
+---
+
+## MCP Tool Reference
+
+### mcp__kernelgen-mcp__optimize_kernel
+
+Optimize Triton kernel code. Can be used for performance optimization or error fixing.
+
+**Input Parameters:**
+```json
+{
+  "kernel_name": "Operator name",
+  "triton_code": "Current complete Triton code",
+  "func_desc": "Operator function description + optimization context summary",
+  "check_result": { "success": false, "error": "Error message" },
+  "device": "Target chip type"
+}
+```
+
+**Returns:**
+```json
+{
+  "triton_code": "Optimized/fixed complete code"
+}
+```
+
+**Usage Scenarios:**
+1. **Performance optimization**: Provide `kernel_name`, `triton_code`, `func_desc`
+2. **Error fixing**: Additionally provide `check_result`
+3. **Fix after optimization**: Provide both `check_result` + `func_desc`
+
+**Important**: MCP-returned code should be reviewed by CC for quality. If the code has obvious issues, CC should optimize it independently or make corrections based on the MCP result.
+
+---
+
+## vLLM Core Mechanism Reference
+
+### CustomOp Registration & Dispatch
+1. `@CustomOp.register("name")` decorator registers the class to `op_registry`
+2. `CustomOp.__init__` calls `dispatch_forward()` to select the forward method based on platform
+3. Benchmark instantiates operators via `op_registry[func_name]()`
+
+### Triton Operator Multi-GPU Safety
+All Triton wrappers must wrap kernel launches with `with torch.cuda.device(input.device):` to prevent launching kernels on the wrong GPU in multi-GPU scenarios.
+
+### Difference Between Triton Ops and C Ops in Tests
+- C ops: Verified with `opcheck(fn, (out, x))`
+- Triton ops: **Cannot use opcheck** (no `_schema` attribute), automatically determined via `hasattr(fn, '_schema')`
+
+### Kernel Pattern Identification
+- **Pattern A (Pointwise)**: 1D grid, `n_elements`, `program_id(0)` → common for `act` type
+- **Pattern B (Row-based)**: 2D grid, `o_stride/x_stride`, `program_id(0)+program_id(1)` → common for `act_and_mul` type
+
+---
+
+## Quick Reference: Naming Lookup Table
+
+Using `relu` + `huawei` as an example:
+
+| Location | Content |
+|----------|---------|
+| activation.py — kernel | `def _relu_huawei_kernel(...)` |
+| activation.py — wrapper | `def relu_huawei_triton(output, input)` |
+| activation.py — class | `@CustomOp.register("relu_huawei")` / `class ReluHuawei(CustomOp)` |
+| activation.py — registry | `"relu_huawei": lambda: ReluHuawei()` (in `_ACTIVATION_REGISTRY`) |
+| test_activation.py — import | `from ... import ReluHuawei, relu_huawei_triton` |
+| test_activation.py — param | `pytest.param((ReluHuawei, relu_huawei_triton), id="ReluHuawei")` |
+| benchmark — choices | `"relu_huawei"` |
+| benchmark — run command | `--func-name relu_huawei` |
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Python environment missing torch/triton | Automatically scan conda environments or create new environment |
+| vLLM project directory not found | Ask user to provide vLLM repository root path |
+| CUDA not available | Warn user that tests will fail |
+| MCP service unavailable | Error: `ERROR: kernelgen-mcp MCP server not available.` |
+| Source directory missing required files | Error with list of missing files, abort |
+| PHASE 2 correctness fails after 3 fix attempts | Error: `FAILED_CORRECTNESS`, abort |
+| PHASE 5 vLLM verification fails after 3 attempts | Error: `FAILED_INTEGRATION`, preserve files for manual debugging |
+| MCP returns unusable code | Skip that iteration, log the reason, continue to next iteration |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| SUCCESS | Target speedup achieved and vLLM integration verification passed |
+| PARTIAL | Speedup improved but did not reach target, vLLM integration completed |
+| FAILED_CORRECTNESS | Correctness cannot pass during optimization phase |
+| FAILED_INTEGRATION | Optimization succeeded but vLLM integration verification failed |
+| FAILED_MCP | MCP service error |
+| NO_TEST | Source directory missing test files |

--- a/kernelgen-mcp/kernelgen-optimize.md
+++ b/kernelgen-mcp/kernelgen-optimize.md
@@ -1,0 +1,594 @@
+
+# Triton Kernel Optimization Skill (MCP Version)
+
+Optimize Triton kernels using expert knowledge from MCP service. Uses the `optimize_kernel` tool from the `kernelgen-mcp` MCP server.
+
+## Prerequisites
+
+- `kernelgen-mcp` MCP server must be configured and running
+- Python environment with `torch` and `triton` installed (dynamically detected in PHASE 0)
+- If the operator code imports flag_gems, `flag_gems` must also be installed (detected in PHASE 0)
+
+## Arguments
+
+- `$ARGUMENTS` - Space-separated parameters:
+  1. Operator directory path (required)
+  2. Target speedup ratio (optional, default 1.2)
+  3. Maximum optimization iterations (optional, default 10)
+
+Examples:
+- `/optimize-triton-mcp /path/to/rot90` — Default target 1.2x, max 10 iterations
+- `/optimize-triton-mcp /path/to/rot90 1.5` — Target 1.5x, max 10 iterations
+- `/optimize-triton-mcp /path/to/rot90 1.5 20` — Target 1.5x, max 20 iterations
+
+---
+
+## Optimization Workflow
+
+### PHASE 0: Environment Detection & Initialization
+
+**Step 0.0: Dynamically Detect Python Environment** ⭐
+
+**Step 0.0a: Try Current Python**
+
+```bash
+python -c "
+import torch, triton
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('cuda=' + str(torch.version.cuda))
+print('cuda_available=' + str(torch.cuda.is_available()))
+"
+```
+
+- If successful → `PYTHON_CMD=python`, continue
+- If failed (import error) → proceed to Step 0.0b
+
+**Step 0.0b: Scan Conda Environments**
+
+```bash
+for env in $(conda env list --json | python -c "import sys,json; print('\n'.join(json.load(sys.stdin)['envs']))"); do
+  name=$(basename "$env")
+  if conda run -n "$name" python -c "import torch, triton" 2>/dev/null; then
+    echo "FOUND_ENV=$name"
+    break
+  fi
+done
+```
+
+- Found → `PYTHON_CMD=conda run -n {found_env} python`
+- Not found → proceed to Step 0.0c
+
+**Step 0.0c: Auto-create Environment (only if both 0.0a and 0.0b fail)**
+
+**1. Detect CUDA Version**
+
+```bash
+nvidia-smi | grep -oP "CUDA Version: \K[\d.]+"
+```
+
+Fallback:
+```bash
+nvcc --version 2>/dev/null | grep -oP "release \K[\d.]+"
+```
+
+**2. Create Conda Environment and Install Base Dependencies**
+
+```bash
+ENV_NAME="triton_opt_env"
+conda create -n ${ENV_NAME} python=3.10 -y
+```
+
+**3. Install PyTorch (select wheel based on CUDA version)**
+
+| CUDA Version | Install Command |
+|-------------|----------------|
+| 11.8 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu118` |
+| 12.1 | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu121` |
+| 12.4+ | `conda run -n ${ENV_NAME} pip install torch --index-url https://download.pytorch.org/whl/cu124` |
+| Uncertain | Ask the user |
+
+**4. Install Triton and Test Dependencies**
+
+```bash
+conda run -n ${ENV_NAME} pip install triton pytest numpy
+```
+
+**5. Verify Installation**
+
+```bash
+conda run -n ${ENV_NAME} python -c "
+import torch, triton
+print('torch=' + torch.__version__)
+print('triton=' + triton.__version__)
+print('cuda_available=' + str(torch.cuda.is_available()))
+"
+```
+
+- Success → `PYTHON_CMD=conda run -n ${ENV_NAME} python`
+- Failure → report error and abort
+
+**Step 0.0d: Check FlagGems Dependency (on demand)** ⭐
+
+Check if operator source code imports flag_gems:
+
+```bash
+grep -l "import flag_gems\|from flag_gems" <operator_path>/*.py 2>/dev/null
+```
+
+If the operator code depends on flag_gems, ensure it is installed:
+
+```bash
+${PYTHON_CMD} -c "import flag_gems; print('flag_gems=' + flag_gems.__version__)" 2>&1
+```
+
+- Already installed → continue
+- Not installed → install FlagGems following these steps:
+
+**FlagGems Installation Process** (ref: https://github.com/FlagOpen/FlagGems):
+
+1. Locate FlagGems project directory:
+```bash
+for candidate in "../FlagGems" "../../FlagGems" "../../flagems/FlagGems"; do
+  if [ -f "$candidate/pyproject.toml" ] && grep -q "flag.gems" "$candidate/pyproject.toml" 2>/dev/null; then
+    echo "FLAGGEMS_ROOT=$(cd "$candidate" && pwd)"
+    break
+  fi
+done
+```
+
+2. Install build dependencies:
+```bash
+${PYTHON_CMD} -m pip install -U scikit-build-core>=0.11 pybind11 ninja cmake
+```
+
+3. Install FlagGems in editable mode (pure Python, no C extension compilation):
+```bash
+cd ${FLAGGEMS_ROOT} && ${PYTHON_CMD} -m pip install --no-build-isolation -e .
+```
+
+4. Install test dependencies:
+```bash
+${PYTHON_CMD} -m pip install "pytest>=7.1.0" "numpy>=1.26" "scipy>=1.14" PyYAML sqlalchemy packaging
+```
+
+5. Verify installation:
+```bash
+${PYTHON_CMD} -c "
+import flag_gems
+print('flag_gems=' + flag_gems.__version__)
+print('device=' + str(flag_gems.device))
+"
+```
+
+If the above steps fail (cannot locate project directory or installation error), ask the user: `FlagGems is not installed. Please provide the FlagGems repository root path, or install it manually and retry.`
+
+**Step 0.0e: Record Environment Variables**
+
+All subsequent commands use `${PYTHON_CMD}` instead of hardcoded `python`.
+
+**Step 0.1: Create Output Directory**
+```bash
+OUTPUT_DIR="<operator_path>_mcp_output_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$OUTPUT_DIR/iterations"
+```
+
+**Step 0.2: Initialize Version Management & Optimization Log**
+
+Maintain the following runtime state (tracked in memory, with file backups):
+
+```
+# Version management
+safe_version_code = None       # Latest Triton code that passed correctness tests
+safe_version_speedup = None    # Speedup of the safe version
+best_version_code = None       # Code with the best historical speedup
+best_version_speedup = 0       # Best historical speedup
+
+# Optimization log (list, appended each iteration)
+optimization_log = []
+# Each record format:
+# {
+#   "iteration": 1,
+#   "action": "Optimization description, e.g.: Increased BLOCK_SIZE from 128 to 256",
+#   "correctness": true/false,
+#   "speedup": 1.05 or null (when correctness fails),
+#   "status": "applied" / "rolled_back" / "fixed_then_applied"
+# }
+```
+
+**Step 0.3: Version File Backup Rules**
+
+Whenever safe_version is updated, also back up the code to `$OUTPUT_DIR/iterations/`:
+```bash
+cp *_triton.py "$OUTPUT_DIR/iterations/triton_iter_{N}_safe.py"
+```
+This ensures rollback doesn't depend on memory and has reliable file backups.
+
+---
+
+### PHASE 1: Pre-checks
+
+**Step 1.1: Verify Directory Structure**
+
+Check required files:
+- `*_triton.py` - Triton implementation (required)
+- `*_torch.py` - PyTorch baseline (required)
+- `test_*.py` or `*_test.py` - Test file (required, abort if missing)
+- `benchmark_*.py` or `*_benchmark.py` - Performance test (required)
+
+**Step 1.2: Read and Analyze Source Files**
+
+Read all files, focusing on the following:
+
+**1.2a: Triton Code Analysis**
+- Identify kernel functions and wrapper functions
+- Check for known code defects (e.g., function name reference errors, undefined variables)
+- Record current BLOCK_SIZE, num_warps, and other configurations
+
+**1.2b: Triton Compatibility Pre-check (Important!)**
+
+Before starting optimization, identify the following Triton limitations and record them to avoid repeated pitfalls:
+
+| Feature | Supported dtypes | Unsupported dtypes |
+|---------|-----------------|-------------------|
+| `tl.atomic_add` | float32, float16, int32 | **bfloat16**, int8, int16, int64, float64 |
+| `tl.atomic_max/min` | int32, int64 | All floating-point types |
+| `tl.atomic_cas` | int32, int64 | Floating-point types |
+
+Record these limitations as `dtype_constraints`, passed as constraints in subsequent optimization and MCP calls.
+
+**1.2c: Benchmark Review (Important!)** ⭐
+
+**Must review benchmark code before running benchmarks**, checking for these issues:
+
+1. **Fairness check**: Are PyTorch baseline and Triton implementation measured on the same device?
+   - Check for `.cpu()` calls causing PyTorch to be measured on CPU while Triton runs on GPU
+   - If found, **fix the benchmark immediately** so both use `triton.testing.do_bench` on GPU
+2. **Data scale check**: Are the tensor sizes large enough?
+   - Too small sizes (e.g., 64 elements) are dominated by kernel launch overhead and can't show Triton's advantage
+   - Recommend at least 1K~16K level update counts
+3. **Measurement method check**: Is `triton.testing.do_bench` or `torch.cuda.Event` properly used for GPU timing?
+   - `time.perf_counter()` is only suitable for CPU timing, not GPU kernel timing
+4. **Warmup check**: Are there enough warmup iterations (recommend ≥10)?
+
+If benchmark issues are found, **fix them before PHASE 2** and record the fixes in the optimization log.
+
+---
+
+### PHASE 2: Correctness Loop (max 3 iterations)
+
+**Step 2.1: Run Tests**
+```bash
+cd <operator_path> && ${PYTHON_CMD} -m pytest test_*.py -v 2>&1
+```
+
+**Step 2.2: Tests Pass → Save as safe_version, proceed to PHASE 3**
+
+Save current code as `safe_version_code` and also set as `best_version_code`.
+Back up file to `$OUTPUT_DIR/iterations/triton_iter_0_safe.py`.
+
+**Step 2.3: Tests Fail → Call MCP to Fix**
+
+Call the `mcp__kernelgen-mcp__optimize_kernel` tool with the `check_result` parameter to fix:
+
+```
+Use MCP tool: mcp__kernelgen-mcp__optimize_kernel
+
+Parameters:
+- kernel_name: Operator name (extracted from filename or directory name)
+- triton_code: Complete code of the current Triton implementation
+- func_desc: Operator function description (optional)
+- check_result: Dictionary containing error information, format:
+  {
+    "success": false,
+    "error": "Error stack trace",
+    "test_case": "Description of the failed test case"
+  }
+
+Returns:
+- triton_code: Fixed Triton code
+```
+
+---
+
+### PHASE 3: Performance Optimization Loop (max {max_iterations} iterations, default 10)
+
+**Step 3.1: Run Benchmark**
+```bash
+cd <operator_path> && ${PYTHON_CMD} benchmark_*.py 2>&1
+```
+
+Parse benchmark output, extract PyTorch time, Triton time, and speedup for each input size.
+Record current overall speedup, update `safe_version_speedup`.
+If this is the first benchmark, also record as `initial_speedup`.
+
+**Step 3.2: Check Exit Conditions**
+
+- Target speedup reached → update `best_version`, proceed to PHASE 4
+- Reached `max_iterations` → restore `best_version_code` to file, proceed to PHASE 4
+- Current speedup > `best_version_speedup` → update `best_version_code` and `best_version_speedup`
+
+**Step 3.3: Profiling Analysis (execute on first iteration and key iterations)** ⭐
+
+Before the first optimization, and when speedup shows no improvement for 2 consecutive iterations, perform profiling analysis to precisely locate bottlenecks.
+
+**Method**: Insert `torch.cuda.Event` timing points at key positions in the wrapper code, measuring:
+1. **Index preprocessing time** (broadcast, flat_idx calculation, and other Python-side operations)
+2. **Data preparation time** (clone, contiguous, dtype conversions, etc.)
+3. **Kernel execution time** (pure Triton kernel portion)
+4. **Post-processing time** (dtype back-conversion, etc.)
+
+Record results as `profiling_breakdown`, format:
+```
+profiling_breakdown = {
+    "index_prep_ms": 0.05,
+    "data_prep_ms": 0.08,
+    "kernel_ms": 0.01,
+    "postprocess_ms": 0.02,
+    "total_triton_ms": 0.16,
+    "pytorch_baseline_ms": 0.02,
+    "bottleneck": "data_prep"  # The phase with the largest proportion
+}
+```
+
+This profiling result will be passed to MCP in Step 3.4, enabling it to precisely optimize the bottleneck.
+
+**Step 3.4: Build Optimization Context Summary** ⭐
+
+Before calling MCP, you must build a structured optimization context summary and pass it to MCP via the `func_desc` parameter.
+This is a critical step to ensure MCP understands the current optimization state.
+
+Summary format:
+
+```
+func_desc content template:
+
+"Operator: {op_name}
+Function: {brief description of operator function}
+
+== Current Optimization State ==
+Iteration: #{N} (max {max_iterations})
+Current speedup: {current_speedup}x
+Target speedup: {target_speedup}x
+Best historical speedup: {best_version_speedup}x
+
+== Triton Compatibility Constraints ==
+{dtype_constraints content, e.g.: bf16 doesn't support atomic_add, needs upcast to float32}
+
+== Profiling Analysis (if available) ==
+| Phase | Time (ms) | Proportion |
+|-------|-----------|------------|
+| Index Prep | {x}ms | {y}% |
+| Data Prep | {x}ms | {y}% |
+| Kernel Exec | {x}ms | {y}% |
+| Post-process | {x}ms | {y}% |
+Bottleneck: {bottleneck}
+
+== Benchmark Details ==
+| Input Size | PyTorch (ms) | Triton (ms) | Speedup |
+|------------|-------------|-------------|---------|
+| {size_1}   | {torch_ms}  | {triton_ms} | {spd}x  |
+| ...        | ...         | ...         | ...     |
+
+== Optimization History ==
+{Iterate through optimization_log list, listing each entry:}
+- Iter {i}: {action}, Result: {status}, Speedup: {speedup}x
+- Iter {j}: {action}, Result: rolled_back (correctness failure)
+- ...
+
+== Bottleneck Analysis ==
+{Analyze based on benchmark and profiling data: whether bottleneck is in wrapper or kernel, compute-bound or memory-bound, etc.}
+
+== Optimization Constraints (Important!) ==
+- Do not significantly increase kernel complexity or parameter count
+- If bottleneck is in wrapper rather than kernel, focus on optimizing wrapper logic (reduce clone/contiguous/dtype conversions)
+- Must follow the Triton compatibility constraints above, do not use unsupported dtype + atomic combinations
+- Optimized code must maintain the same wrapper interface (input/output signatures unchanged)"
+```
+
+**Step 3.5: Call MCP to Get Optimized Code**
+
+Call MCP tool to get optimized code:
+
+```
+Use MCP tool: mcp__kernelgen-mcp__optimize_kernel
+
+Parameters:
+- kernel_name: Operator name (required, extracted from filename or directory name, e.g., "relu", "softmax")
+- triton_code: Complete code of current safe_version (required)
+- func_desc: Optimization context summary built in Step 3.4 (required, including current state, benchmark data, optimization history, constraints)
+- gpu: Target chip type (optional), supports:
+  - "nvidia" - NVIDIA GPU
+  - "haiguang" - Haiguang DCU
+  - "moore" - Moore Threads
+  - "tianshu" - Tianshu Zhixin
+  - "huawei" - Huawei Ascend
+
+Returns:
+- triton_code: Fully optimized Triton code
+```
+
+The MCP server will, based on the provided context:
+1. Understand current optimization progress and historical attempts, avoiding repetition of failed strategies
+2. Analyze performance bottlenecks based on benchmark and profiling data
+3. Generate targeted optimization code
+
+**Step 3.6: MCP Result Usability Check** ⭐
+
+Before writing to file, **must first check if the MCP-returned code is usable**:
+
+1. **Basic syntax check**: Is the code valid Python? Does it contain complete kernel and wrapper functions?
+2. **Complexity check**: Compared to the original code, if the new code's kernel parameter count increases more than 3x, or line count increases more than 5x, consider it over-complex and skip this iteration
+3. **Interface compatibility check**: Is the wrapper function's input/output signature consistent with the original version?
+4. **Known defect check**: Does it reference undefined variables? Does it use operations marked as unsupported in dtype_constraints?
+
+If the check fails:
+- Log entry: `{"iteration": N, "action": "MCP returned unusable code: {reason}", "status": "skipped"}`
+- **Do not write to file**, proceed directly to next iteration (if remaining iterations available)
+- In the next MCP call, explain in func_desc why the previous iteration was skipped, guiding MCP to generate a more reasonable solution
+
+**Step 3.7: Apply Optimized Code**
+
+Write the MCP-returned `triton_code` to the `*_triton.py` file.
+Also back up the pre-optimization `safe_version_code` (memory + file).
+
+**Step 3.8: Verify Correctness**
+```bash
+cd <operator_path> && ${PYTHON_CMD} -m pytest test_*.py -v 2>&1
+```
+
+Handle results by branch:
+
+**Case A: Tests Pass**
+- Log optimization: `{"iteration": N, "action": "MCP optimization", "correctness": true, "speedup": null, "status": "pending_benchmark"}`
+- Update `safe_version_code` to current code
+- Back up file to `$OUTPUT_DIR/iterations/triton_iter_{N}_safe.py`
+- → Return to Step 3.1 to run benchmark and fill in speedup data
+
+**Case B: Tests Fail → Call MCP to Fix (max 2 fix attempts)**
+
+Do not roll back immediately! Try letting MCP fix it first:
+
+```
+Use MCP tool: mcp__kernelgen-mcp__optimize_kernel
+
+Parameters:
+- kernel_name: Operator name
+- triton_code: Current failing code (not the rolled-back code)
+- func_desc: Optimization context summary + additional note:
+  "Note: The last optimization caused correctness failure. Please fix correctness while maintaining performance optimizations.
+   Triton compatibility constraints: {dtype_constraints}
+   Error type: {key info extracted from error message, e.g., 'bf16 doesn't support atomic_add'}"
+- check_result: {
+    "success": false,
+    "error": "Error stack trace from pytest output",
+    "test_case": "Name and parameters of the failed test case"
+  }
+
+Returns:
+- triton_code: Fixed Triton code
+```
+
+After fix, run correctness tests again:
+- Fix successful (tests pass) → log status="fixed_then_applied", update `safe_version_code`, return to Step 3.1
+- Fix failed (both fix attempts failed) → **Roll back** to `safe_version_code` (restore from backup file), log status="rolled_back", proceed to next iteration
+
+---
+
+### PHASE 4: Generate Report
+
+**Step 4.1: Generate Final Report** `final_report.md`
+
+```markdown
+# Triton Kernel Optimization Report (MCP)
+
+## Summary
+| Metric | Value |
+|--------|-------|
+| Operator | {op_name} |
+| Initial Speedup | {initial}x |
+| Final Speedup | {final}x |
+| Best Speedup | {best_version_speedup}x |
+| Total Iterations | {N} |
+| Status | {SUCCESS/PARTIAL/FAILED} |
+
+## Optimization History
+| Iter | Action | Correctness | Speedup | Status |
+|------|--------|-------------|---------|--------|
+| 1    | {desc}  | PASS        | 1.05x   | applied |
+| 2    | {desc}  | FAIL→FIX    | 1.12x   | fixed_then_applied |
+| 3    | {desc}  | FAIL        | -       | rolled_back |
+| ...  | ...    | ...         | ...     | ... |
+
+## Performance Comparison (Best Version)
+| Input Size | PyTorch (ms) | Triton (ms) | Speedup |
+|------------|--------------|-------------|---------|
+...
+
+## Profiling Breakdown (if available)
+| Phase | Time (ms) | Percentage |
+|-------|-----------|------------|
+| Index Prep | ... | ...% |
+| Data Prep | ... | ...% |
+| Kernel | ... | ...% |
+| Postprocess | ... | ...% |
+```
+
+**Step 4.2: Output Summary**
+```
+============================================================
+OPTIMIZATION COMPLETE (MCP)
+============================================================
+Operator: {op_name}
+Status: {SUCCESS | PARTIAL | FAILED}
+Initial → Final Speedup: {initial}x → {final}x
+Output Directory: {OUTPUT_DIR}
+============================================================
+```
+
+---
+
+## MCP Tool Reference
+
+### mcp__kernelgen-mcp__optimize_kernel
+
+Optimize Triton kernel code. Can be used for performance optimization or error fixing.
+
+**Input Parameters:**
+```json
+{
+  "kernel_name": "Operator name, e.g., relu, softmax, add, etc.",
+  "triton_code": "Complete code of the current Triton implementation",
+  "func_desc": "Operator function description + optimization context summary (strongly recommended, see below)",
+  "check_result": {
+    "success": false,
+    "error": "Error message (optional, for fix mode)"
+  },
+  "gpu": "Target chip type (optional)"
+}
+```
+
+**Returns:**
+```json
+{
+  "triton_code": "Optimized/fixed complete Triton code"
+}
+```
+
+**Usage Scenarios:**
+1. **Performance optimization**: Provide `kernel_name`, `triton_code`, `func_desc` (with optimization context summary)
+2. **Error fixing**: Additionally provide `check_result` containing error information
+3. **Fix after optimization**: Provide both `check_result` (correctness error) and `func_desc` (with optimization context), letting MCP fix correctness while maintaining performance optimizations
+
+**About Passing Optimization Context via func_desc (Important):**
+
+In the PHASE 3 optimization loop, `func_desc` is not just an operator function description — it should also include the complete optimization context summary.
+This enables MCP to:
+- Understand current optimization progress, avoiding repetition of failed strategies
+- Locate performance bottlenecks based on benchmark and profiling data
+- Follow Triton compatibility constraints, avoiding generation of incompatible code
+- Make better decisions based on optimization history
+
+See PHASE 3 Step 3.4 for the detailed format.
+
+---
+
+## Error Handling
+
+If the MCP service is unavailable:
+```
+ERROR: kernelgen-mcp MCP server not available.
+Please ensure the MCP server is configured and running.
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| SUCCESS | Target speedup achieved |
+| PARTIAL | Correctness passed, speedup improved but did not reach target |
+| FAILED_CORRECTNESS | Still cannot pass tests after 3 iterations |
+| FAILED_MCP | MCP service error |
+| NO_TEST | Test file missing |

--- a/kernelgen-mcp/kernelgen-specialize-for-flaggems.md
+++ b/kernelgen-mcp/kernelgen-specialize-for-flaggems.md
@@ -1,0 +1,719 @@
+---
+name: kernelgen-specialize-for-flaggems
+description: Automatically migrate GPU Triton operators to Ascend NPU using the dedicated MCP specialize_kernel tool and integrate into the FlagGems project. Complete workflow: MCP auto-specialization -> FlagGems adaptation -> file placement -> operator registration -> auto testing -> performance verification. Supports four integration modes: vendor-ops (default), vendor-fused, override-builtin, experimental. Trigger scenarios: migrating CUDA Triton operators to FlagGems, adding Ascend backend operators for FlagGems, optimizing NPU implementation of existing FlagGems operators.
+---
+
+# GPU Triton Operator MCP Auto-Migration + FlagGems Integration
+
+This skill combines the MCP auto-specialization tool (`specialize_kernel`) with FlagGems framework integration, enabling a fully automated workflow from GPU Triton operators to Ascend NPU FlagGems operators.
+
+---
+
+## Usage
+
+```bash
+/kernelgen-specialize-for-flaggems <source_file_path_or_op_name> [integration_mode] [output_directory]
+```
+
+**Parameters**:
+- `source_file_path_or_op_name`: Required, source file path or operator name of the GPU Triton operator
+- `integration_mode`: Optional, default `vendor-ops`
+  - `vendor-ops`: Ascend-specific operator (default), placed in `runtime/backend/_ascend/ops/`
+  - `vendor-fused`: Ascend fused operator, placed in `runtime/backend/_ascend/ops/`
+  - `override-builtin`: Override built-in operator, placed in `src/flag_gems/ops/`
+  - `experimental`: Experimental operator, placed in `experimental_ops/`
+- `output_directory`: Optional, default `/home/FlagGems`
+
+**Examples**:
+```bash
+# Default mode (vendor-ops)
+/kernelgen-specialize-for-flaggems /home/test/gelu_kernel.py
+
+# Specify integration mode
+/kernelgen-specialize-for-flaggems /home/test/softmax.py vendor-fused
+
+# Specify output directory
+/kernelgen-specialize-for-flaggems /home/test/layernorm.py experimental /home/MyFlagGems
+```
+
+---
+
+## Automated Workflow (8 Steps)
+
+### 1. Read Source Code
+Read the GPU Triton kernel code from the file path provided by the user.
+
+### 2. Extract Kernel Information
+Automatically extract:
+- Kernel name (e.g., `gelu_kernel`)
+- Function signature and parameters
+- Operator function description
+
+### 3. Call MCP Tool for Auto-Specialization
+Use the `mcp__kernelgen-mcp__specialize_kernel` tool:
+```python
+{
+    "kernel_name": "gelu",
+    "triton_code": "<complete source code>",
+    "target_platform": "huawei",
+    "func_desc": "GELU activation function",
+    "arg_names": "x",
+    "arg_type": "torch.Tensor",
+    "arg_descs": "input tensor",
+    "output_arg_desc": "output tensor"
+}
+```
+
+### 4. FlagGems Framework Adaptation
+Adapt the specialized code returned by MCP to FlagGems format based on the integration mode:
+
+#### vendor-ops / vendor-fused Mode
+```python
+import torch
+import triton
+import triton.language as tl
+from flag_gems.utils import libentry
+from flag_gems.utils.shape_utils import volume
+
+@libentry()
+@triton.jit
+def gelu_kernel(
+    in_ptr,
+    out_ptr,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_SUB: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = pid * BLOCK_SIZE
+
+    for sub in range(0, BLOCK_SIZE, BLOCK_SIZE_SUB):
+        idx = offset + sub + tl.arange(0, BLOCK_SIZE_SUB)
+        mask = idx < N
+        x = tl.load(in_ptr + idx, mask=mask, care_padding=False)
+        out = x * 0.5 * (1.0 + tl.erf(x / 1.4142135623730951))
+        tl.store(out_ptr + idx, out, mask=mask)
+
+def gelu(x: torch.Tensor) -> torch.Tensor:
+    N = volume(x.shape)
+    out = torch.empty_like(x)
+
+    # Dynamically compute BLOCK_SIZE
+    min_block = triton.next_power_of_2(triton.cdiv(N, 65535))
+    BLOCK_SIZE = max(32768, min_block)
+    BLOCK_SIZE_SUB = 1024
+
+    grid = lambda meta: (triton.cdiv(N, BLOCK_SIZE),)
+
+    with torch_device_fn.device(x.device):
+        gelu_kernel[grid](x, out, N, BLOCK_SIZE, BLOCK_SIZE_SUB)
+
+    return out
+```
+
+#### override-builtin Mode
+```python
+import torch
+import triton
+import triton.language as tl
+from flag_gems.utils import pointwise_dynamic
+
+@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def gelu_kernel(x):
+    return x * 0.5 * (1.0 + tl.erf(x / 1.4142135623730951))
+
+def gelu(A):
+    return gelu_kernel(A)
+```
+
+#### experimental Mode
+```python
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def gelu_kernel_experimental(
+    in_ptr,
+    out_ptr,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_SUB: tl.constexpr
+):
+    # MCP specialized code
+    pid = tl.program_id(0)
+    # ... full implementation
+    pass
+
+def gelu_experimental(x: torch.Tensor) -> torch.Tensor:
+    # Experimental wrapper function
+    pass
+```
+
+### 5. File Placement
+Save files to the correct location based on integration mode:
+
+| Mode | Target Directory | Filename Format |
+|------|-----------------|-----------------|
+| vendor-ops | `runtime/backend/_ascend/ops/` | `<op_name>.py` |
+| vendor-fused | `runtime/backend/_ascend/ops/` | `<op_name>_fused.py` |
+| override-builtin | `src/flag_gems/ops/` | `<op_name>.py` |
+| experimental | `experimental_ops/` | `<op_name>_exp.py` |
+
+### 6. Operator Registration
+Automatically register operators based on mode:
+
+#### vendor-ops Registration
+Update `runtime/backend/_ascend/__init__.py`:
+```python
+from .ops.gelu import gelu
+
+__all__ = ["gelu", ...]
+```
+
+#### override-builtin Registration
+Update `src/flag_gems/ops/__init__.py`:
+```python
+from .gelu import gelu
+
+__all__ = ["gelu", ...]
+```
+
+#### experimental Registration
+Update `experimental_ops/__init__.py`:
+```python
+from .gelu_exp import gelu_experimental
+
+__all__ = ["gelu_experimental", ...]
+```
+
+### 7. Auto Test Execution
+
+#### Unit Tests
+```bash
+cd /home/FlagGems
+
+# vendor-ops / override-builtin
+pytest tests/test_unary_pointwise_ops.py::test_gelu -v --tb=short
+
+# experimental
+pytest experimental_tests/test_<op_name>_exp.py -v --tb=short
+```
+
+Record test results:
+- Pass/fail status
+- Execution time
+- Error messages (if any)
+
+#### Performance Tests
+```bash
+cd /home/FlagGems
+
+# vendor-ops / override-builtin
+pytest benchmark/test_unary_pointwise_perf.py::test_perf_gelu -v -s --tb=short
+
+# experimental
+pytest experimental_tests/benchmark_<op_name>_exp.py -v -s --tb=short
+```
+
+Record performance data:
+- NPU execution time
+- CPU execution time
+- Speedup ratio
+
+### 8. Generate Integration Report
+Automatically generate `FLAGGEMS_INTEGRATION_REPORT.md` containing:
+
+```markdown
+# <op_name> FlagGems Integration Report
+
+**Migration date**: 2026-03-23
+**Source platform**: CUDA GPU
+**Target platform**: Ascend NPU
+**Migration method**: MCP auto-specialization + FlagGems integration
+**Integration mode**: vendor-ops
+
+---
+
+## Integration Results Overview
+
+### MCP Auto-Specialization
+- **Status**: Success
+- **Specialized code**: Generated
+- **Key optimizations**:
+  - Dynamic BLOCK_SIZE computation (ensuring coreDim <= 65535)
+  - Intra-core tiling (BLOCK_SIZE_SUB=1024)
+  - care_padding=False optimization
+
+### FlagGems Adaptation
+- **Target file**: runtime/backend/_ascend/ops/gelu.py
+- **Operator registration**: __init__.py updated
+- **Framework compatibility**: Using @libentry() decorator
+
+### Unit Tests
+- **Status**: All passed
+- **Test cases**: 12/12
+- **Execution time**: 8.32s
+
+### Performance Tests
+- **Status**: All passed
+- **Test cases**: 8/8
+- **Execution time**: 5.67s
+
+---
+
+## Performance Data Analysis
+
+| Input Shape | Data Type | NPU (ms) | CPU (ms) | Speedup |
+|-------------|-----------|----------|----------|---------|
+| (1024,) | float32 | 0.12 | 0.45 | 3.75x |
+| (1024, 1024) | float32 | 1.23 | 8.91 | 7.24x |
+| (512, 512, 4) | float16 | 0.89 | 6.34 | 7.12x |
+
+**Average speedup**: 6.04x
+
+---
+
+## Code Comparison
+
+### Before MCP Specialization (GPU)
+```python
+@triton.jit
+def gelu_kernel(x_ptr, out_ptr, N, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offset < N
+    x = tl.load(x_ptr + offset, mask=mask)
+    out = x * 0.5 * (1.0 + tl.erf(x / 1.4142135623730951))
+    tl.store(out_ptr + offset, out, mask=mask)
+```
+
+### After MCP Specialization (NPU + FlagGems)
+```python
+@libentry()
+@triton.jit
+def gelu_kernel(in_ptr, out_ptr, N, BLOCK_SIZE: tl.constexpr, BLOCK_SIZE_SUB: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = pid * BLOCK_SIZE
+
+    for sub in range(0, BLOCK_SIZE, BLOCK_SIZE_SUB):
+        idx = offset + sub + tl.arange(0, BLOCK_SIZE_SUB)
+        mask = idx < N
+        x = tl.load(in_ptr + idx, mask=mask, care_padding=False)
+        out = x * 0.5 * (1.0 + tl.erf(x / 1.4142135623730951))
+        tl.store(out_ptr + idx, out, mask=mask)
+```
+
+**Key improvements**:
+- Added BLOCK_SIZE_SUB intra-core tiling
+- care_padding=False to reduce dependencies
+- @libentry() FlagGems decorator
+- Dynamic BLOCK_SIZE computation
+
+---
+
+## Verification Checklist
+
+- [x] MCP auto-specialization successful
+- [x] FlagGems framework adaptation complete
+- [x] Files placed in correct directory
+- [x] Operator registered in __init__.py
+- [x] All unit tests passed
+- [x] All performance tests passed
+- [x] Speedup meets expectations (> 3x)
+
+---
+
+## Usage Example
+
+```python
+import torch
+import flag_gems
+
+# Set to use Ascend backend
+flag_gems.use_gems()
+
+x = torch.randn(1024, 1024, device='npu')
+out = torch.nn.functional.gelu(x)  # Automatically uses Ascend-optimized version
+```
+
+---
+
+## Next Steps
+
+1. Validate performance on more input shapes
+2. Fuse with other operators to reduce kernel launch overhead
+3. Adjust BLOCK_SIZE_SUB parameters for further optimization
+4. Consider contributing to the official FlagGems repository
+```
+
+---
+
+## MCP Tool Call Details
+
+### Tool Name
+`mcp__kernelgen-mcp__specialize_kernel`
+
+### Required Parameters
+- `kernel_name` (str): Operator name
+- `triton_code` (str): Complete GPU Triton source code
+- `target_platform` (str): Must be set to `"huawei"`
+
+### Optional Parameters
+- `func_desc` (str): Operator function description
+- `arg_names` (str): Input parameter names (comma-separated)
+- `arg_type` (str): Input parameter types
+- `arg_descs` (str): Input parameter descriptions (comma-separated)
+- `output_arg_desc` (str): Output parameter description
+- `check_result` (dict): Previous verification results (if code has errors that need fixing)
+
+### Return Value
+```python
+{
+    "triton_code": "<Ascend-specialized code>",
+    "mode": "specialize",
+    "target_platform": "huawei"
+}
+```
+
+---
+
+## FlagGems Integration Mode Details
+
+### vendor-ops (Default, Recommended)
+**Applicable scenarios**:
+- Ascend-specific operator implementation
+- Does not affect other backends
+- Requires Ascend-specific optimizations
+
+**Directory structure**:
+```
+runtime/backend/_ascend/ops/
+├── __init__.py
+├── gelu.py
+├── softmax.py
+└── layernorm.py
+```
+
+**Code template**:
+```python
+import torch
+import triton
+import triton.language as tl
+from flag_gems.utils import libentry
+from flag_gems.utils.shape_utils import volume
+
+@libentry()
+@triton.jit
+def kernel(...):
+    # MCP specialized kernel
+    pass
+
+def op_name(x: torch.Tensor) -> torch.Tensor:
+    # Wrapper function
+    with torch_device_fn.device(x.device):
+        kernel[grid](...)
+    return out
+```
+
+### vendor-fused
+**Applicable scenarios**:
+- Multi-operator fusion optimization
+- Ascend-specific fusion patterns
+- Reducing kernel launch overhead
+
+**Naming convention**:
+- Filename: `<op1>_<op2>_fused.py`
+- Function name: `<op1>_<op2>_fused`
+
+**Example**:
+```python
+# gelu_add_fused.py
+def gelu_add_fused(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    # Fused GELU + Add
+    pass
+```
+
+### override-builtin
+**Applicable scenarios**:
+- Replacing FlagGems built-in operators
+- Takes effect globally (all backends)
+- Should be used with caution
+
+**Notes**:
+- Will overwrite the original implementation
+- Must ensure compatibility
+- Recommended to validate in experimental mode first
+
+### experimental
+**Applicable scenarios**:
+- Experimental operators
+- Not yet fully validated
+- Rapid prototyping
+
+**Directory structure**:
+```
+experimental_ops/
+├── __init__.py
+├── gelu_exp.py
+└── experimental_tests/
+    ├── test_gelu_exp.py
+    └── benchmark_gelu_exp.py
+```
+
+---
+
+## Common Issue Handling
+
+### Issue 1: MCP Tool Call Failure
+**Error message**: `MCP server not available`
+
+**Solution**:
+1. Check if MCP service is running
+2. Verify MCP configuration in settings.json
+3. Confirm permission settings include `mcp__kernelgen-mcp__specialize_kernel`
+
+### Issue 2: FlagGems Test Failure
+**Error message**: `ModuleNotFoundError: No module named 'flag_gems'`
+
+**Solution**:
+```bash
+cd /home/FlagGems
+pip install -e .
+```
+
+### Issue 3: Operator Registration Not Taking Effect
+**Symptom**: Original implementation is still used when calling the operator
+
+**Solution**:
+1. Check if `__init__.py` has correct imports
+2. Confirm `flag_gems.use_gems()` has been called
+3. Restart the Python environment
+
+### Issue 4: Performance Below Expectations
+**Symptom**: Speedup < 2x
+
+**Solution**:
+1. Set environment variable: `export TRITON_ALL_BLOCKS_PARALLEL=1`
+2. Adjust BLOCK_SIZE_SUB parameter (try 2048, 4096)
+3. Check input data scale (small data may not be suitable for NPU)
+
+---
+
+## Performance Optimization Recommendations
+
+### 1. Environment Variable Configuration
+```bash
+export TRITON_ALL_BLOCKS_PARALLEL=1  # Reduce scheduling overhead
+export TRITON_DEBUG=1                # Debug mode (optional)
+```
+
+### 2. Tiling Parameter Tuning
+```python
+# Default configuration
+BLOCK_SIZE = 32768
+BLOCK_SIZE_SUB = 1024
+
+# Large data optimization
+BLOCK_SIZE = 65536
+BLOCK_SIZE_SUB = 2048
+
+# Small data optimization
+BLOCK_SIZE = 16384
+BLOCK_SIZE_SUB = 512
+```
+
+### 3. Operator Fusion
+Fuse multiple small operators into one large operator to reduce kernel launch overhead:
+```python
+# Before fusion: 3 kernel launches
+x = gelu(x)
+x = add(x, y)
+x = relu(x)
+
+# After fusion: 1 kernel launch
+x = gelu_add_relu_fused(x, y)
+```
+
+---
+
+## Complete Examples
+
+### Example 1: Migrate GELU Operator (vendor-ops Mode)
+
+**Input**:
+```bash
+/kernelgen-specialize-for-flaggems /home/test/gelu_cuda.py vendor-ops
+```
+
+**Automated workflow**:
+1. Read `/home/test/gelu_cuda.py`
+2. Call MCP tool to specialize for Ascend
+3. Adapt to FlagGems vendor-ops format
+4. Save to `runtime/backend/_ascend/ops/gelu.py`
+5. Update `runtime/backend/_ascend/__init__.py`
+6. Run unit tests: `pytest tests/test_unary_pointwise_ops.py::test_gelu -v`
+7. Run performance tests: `pytest benchmark/test_unary_pointwise_perf.py::test_perf_gelu -v -s`
+8. Generate report: `FLAGGEMS_INTEGRATION_REPORT.md`
+
+**Output**:
+```
+MCP auto-specialization successful
+FlagGems adaptation complete
+File saved: runtime/backend/_ascend/ops/gelu.py
+Operator registration complete
+Unit tests: 12/12 passed (8.32s)
+Performance tests: 8/8 passed (5.67s)
+Average speedup: 6.04x
+
+Detailed report: /home/FlagGems/FLAGGEMS_INTEGRATION_REPORT.md
+```
+
+### Example 2: Migrate Softmax Operator (override-builtin Mode)
+
+**Input**:
+```bash
+/kernelgen-specialize-for-flaggems /home/test/softmax_cuda.py override-builtin
+```
+
+**Notes**:
+- Will overwrite the FlagGems built-in softmax implementation
+- Must ensure the new implementation is compatible with all test cases
+- Recommended to validate in experimental mode first
+
+### Example 3: Migrate Fused Operator (vendor-fused Mode)
+
+**Input**:
+```bash
+/kernelgen-specialize-for-flaggems /home/test/gelu_add_cuda.py vendor-fused
+```
+
+**Output files**:
+- `runtime/backend/_ascend/ops/gelu_add_fused.py`
+- Function name: `gelu_add_fused(x, y)`
+
+---
+
+## Relationship with Other Skills
+
+### vs. kernelgen-specialize
+- **Similarities**: Both use MCP tool for auto-specialization
+- **Differences**: This skill additionally integrates into the FlagGems framework
+
+### vs. kernelgen-specialize
+- **Similarities**: Both integrate into the FlagGems framework
+- **Differences**: This skill uses MCP auto-specialization, no manual code modification needed
+
+### Recommended Use Cases
+- **This skill**: Rapid migration + auto-integration, suitable for most scenarios
+- **kernelgen-specialize**: Only need specialized code, no FlagGems integration needed
+- **kernelgen-specialize**: Need manual control over code details
+
+---
+
+## Technical Details
+
+### MCP Specialization Key Optimizations
+1. **Dynamic BLOCK_SIZE computation**
+   ```python
+   min_block = triton.next_power_of_2(triton.cdiv(N, 65535))
+   BLOCK_SIZE = max(32768, min_block)
+   ```
+
+2. **Intra-core tiling (Sub-tiling)**
+   ```python
+   for sub in range(0, BLOCK_SIZE, BLOCK_SIZE_SUB):
+       idx = offset + sub + tl.arange(0, BLOCK_SIZE_SUB)
+       # Process BLOCK_SIZE_SUB-sized data blocks
+   ```
+
+3. **care_padding=False optimization**
+   ```python
+   x = tl.load(ptr + idx, mask=mask, care_padding=False)
+   ```
+
+### FlagGems Framework Requirements
+1. **Use @libentry() decorator**
+   ```python
+   from flag_gems.utils import libentry
+
+   @libentry()
+   @triton.jit
+   def kernel(...):
+       pass
+   ```
+
+2. **Device context management**
+   ```python
+   from flag_gems.runtime import torch_device_fn
+
+   with torch_device_fn.device(x.device):
+       kernel[grid](...)
+   ```
+
+3. **Shape utility functions**
+   ```python
+   from flag_gems.utils.shape_utils import volume
+
+   N = volume(x.shape)  # Compute total number of elements
+   ```
+
+---
+
+## Limitations and Notes
+
+1. **MCP service dependency**
+   - Requires `kernelgen-mcp` MCP server to be running
+   - Requires network connectivity (if MCP service is remote)
+
+2. **FlagGems environment requirements**
+   - Requires FlagGems installation: `pip install -e /home/FlagGems`
+   - Requires Ascend NPU device and drivers
+
+3. **Code review recommendations**
+   - MCP auto-generated code may require manual review
+   - Recommended to validate in experimental mode first, then switch to vendor-ops
+
+4. **Performance expectations**
+   - Small data (< 1000 elements) may not be suitable for NPU
+   - Recommended to test on actual business data scales
+
+---
+
+## Troubleshooting
+
+### Debug Mode
+```bash
+export TRITON_DEBUG=1
+export TRITON_PRINT_AUTOTUNING=1
+```
+
+### View Generated IR
+```bash
+export TRITON_CACHE_DIR=/tmp/triton_cache
+ls /tmp/triton_cache  # View compilation cache
+```
+
+### Performance Profiling
+```python
+import torch.profiler
+
+with torch.profiler.profile(
+    activities=[torch.profiler.ProfilerActivity.NPU],
+    record_shapes=True
+) as prof:
+    out = gelu(x)
+
+print(prof.key_averages().table(sort_by="npu_time_total"))
+```
+
+---
+
+## References
+
+- [FlagGems Official Documentation](https://github.com/FlagOpen/FlagGems)
+- [Ascend Triton Development Guide](https://www.hiascend.com/document)
+- [MCP Tool Usage Instructions](internal documentation)
+- [kernelgen-specialize Skill](kernelgen-specialize.md)
+- [kernelgen-specialize-for-flaggems Skill](kernelgen-specialize-for-flaggems.md)

--- a/kernelgen-mcp/kernelgen-specialize.md
+++ b/kernelgen-mcp/kernelgen-specialize.md
@@ -1,0 +1,471 @@
+---
+name: kernelgen-specialize
+description: Migrate GPU Triton operators to Huawei Ascend NPU. Supports two modes: (1) Automatic migration - automatically specialize operators to the Ascend platform via the dedicated MCP specialize_kernel tool; (2) Manual migration guide - provides complete architecture difference analysis, code modification steps, common issue resolution (coreDim exceeding limits, UB overflow, memory access alignment, etc.) and performance optimization tips. Trigger scenarios: GPU to NPU migration, device='cuda' changed to 'npu', Ascend adaptation, "Triton migration", "NPU porting", "Ascend migration", etc.
+---
+
+# Complete Guide: Migrating GPU Triton Operators to Ascend NPU
+
+This guide covers the complete process of migrating Triton operators from GPU to Ascend NPU, including architecture difference analysis, code migration steps, common issue resolution, and performance optimization tips.
+
+---
+
+## Quick Migration Checklist
+
+Basic steps for migrating GPU Triton operators to NPU:
+
+- [ ] Add `import torch_npu` import statement
+- [ ] Change `device='cuda'` to `device='npu'`
+- [ ] Remove GPU-specific APIs (e.g., `triton.runtime.driver.active.get_active_torch_device()`)
+- [ ] Remove GPU device consistency check assertions
+- [ ] Check Grid configuration, ensure coreDim <= 65535
+- [ ] Verify BLOCK_SIZE does not cause UB overflow
+- [ ] Ensure memory access alignment: 32 bytes for VV scenarios, 512 bytes for CV scenarios
+
+---
+
+## Automated Migration Tool (MCP Integration)
+
+### Feature Description
+
+By using the dedicated `specialize_kernel` tool from `kernelgen-mcp`, GPU Triton operators can be automatically specialized to the Ascend platform.
+
+### Usage
+
+**Automatic trigger**: When the user mentions requests like "migrate this operator to Ascend", "help me specialize this kernel", etc., the MCP tool is automatically invoked.
+
+**Tool call parameters**:
+- `kernel_name`: Operator name (e.g., "gelu", "softmax")
+- `triton_code`: Complete Triton kernel code string
+- `target_platform`: Set to `"huawei"` (Ascend platform)
+- Other optional parameters:
+  - `func_desc`: Operator function description
+  - `arg_names`: Input parameter names (comma-separated)
+  - `arg_type`: Input parameter types
+  - `arg_descs`: Input parameter descriptions (comma-separated)
+  - `output_arg_desc`: Output parameter description
+  - `check_result`: Previous verification results (if code has errors that need fixing)
+
+### Tool Call Example
+
+```
+Using MCP tool for automatic migration:
+
+mcp__kernelgen-mcp__specialize_kernel:
+  kernel_name: "gelu"
+  triton_code: |
+    @triton.jit
+    def gelu_kernel(x_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        # GELU: x * 0.5 * (1 + erf(x / sqrt(2)))
+        output = x * 0.5 * (1.0 + tl.erf(x / tl.sqrt(2.0)))
+        tl.store(output_ptr + offsets, output, mask=mask)
+  target_platform: "huawei"
+  func_desc: "GELU activation function: output = x * 0.5 * (1 + erf(x / sqrt(2)))"
+  arg_names: "x"
+  arg_type: "torch.Tensor"
+  arg_descs: "input tensor"
+  output_arg_desc: "output tensor, same shape as input"
+```
+
+### Automated Migration Workflow
+
+When the user requests migrating a Triton operator to Ascend, Claude should execute the following steps:
+
+1. **Read source code**: Read the Triton kernel code from the file path provided by the user
+2. **Extract information**: Extract kernel name and parameter information from the code
+3. **Call MCP tool**: Use `mcp__kernelgen-mcp__specialize_kernel` with `target_platform="huawei"`
+4. **Save specialized code**: Save the specialized code returned by MCP to the specified directory
+5. **Copy related files**: Copy test files, benchmark files, and reference implementations to the output directory
+6. **Auto-execute tests**: Run unit tests to verify correctness
+7. **Auto-execute performance tests**: Run benchmarks to obtain speedup data
+8. **Generate test report**: Summarize test results and performance data
+
+### MCP Tool Return Content
+
+The tool returns a dictionary containing the following fields:
+- `triton_code`: Triton kernel code specialized for the Ascend platform
+- `mode`: The operation mode used ("specialize")
+- `target_platform`: The target platform name ("huawei")
+
+### Post-Migration Verification Checklist
+
+After generating code with the MCP tool, the following checks are still required:
+- [ ] Has `import torch_npu` been added
+- [ ] Has `device='cuda'` been changed to `device='npu'`
+- [ ] Have GPU-specific APIs been removed
+- [ ] Does the Grid configuration satisfy coreDim <= 65535
+- [ ] Will BLOCK_SIZE cause UB overflow (192KB limit)
+- [ ] Is memory access alignment correct (32 bytes for VV scenarios, 512 bytes for CV scenarios)
+
+### Auto Test Execution
+
+After migration is complete, the following tests **must** be automatically executed:
+
+#### 1. Unit Tests
+```bash
+cd <output_dir>
+pytest <kernel_name>_test.py -v --tb=short 2>&1 | head -100
+```
+- Verify operator correctness
+- Test multiple input shapes and data types
+- Compare NPU implementation with CPU reference implementation
+- Record pass/fail status and execution time
+
+#### 2. Performance Tests
+```bash
+cd <output_dir>
+pytest <kernel_name>_benchmark.py -v -s --tb=short 2>&1 | head -120
+```
+- Measure Triton(NPU) vs PyTorch(CPU) execution time
+- Calculate speedup ratio
+- Output detailed performance data
+- Timeout setting: 300 seconds
+
+#### 3. Test Report Generation
+
+Automatically generate `TEST_REPORT.md` containing:
+- Pass/fail unit test status (X/Y passed)
+- Performance comparison table (PyTorch vs Triton execution time)
+- Speedup statistics (Speedup: Xx)
+- Performance analysis (data scale, memory access patterns, applicable scenarios)
+- Optimization suggestions (environment variables, Tiling parameters, use cases)
+
+#### 4. Update README
+
+Add test result summary to README.md:
+```markdown
+## Test Results
+
+### Unit Tests: X/Y Passed
+### Performance Tests: X/Y Passed
+
+See [TEST_REPORT.md](TEST_REPORT.md) for detailed test report
+```
+
+### Notes
+
+1. **MCP service dependency**: Requires `kernelgen-mcp` MCP server to be configured
+2. **NPU device requirement**: Tests need to be executed in an environment with Ascend NPU
+3. **Test failure handling**: If tests fail, check Grid configuration, UB usage, memory access alignment; can pass previous error as `check_result` parameter to get auto-fixed code
+4. **Performance optimization**: If speedup is not satisfactory, try setting `export TRITON_ALL_BLOCKS_PARALLEL=1`
+
+---
+
+## Architecture Difference Comparison
+
+### Core Differences Overview
+
+| Dimension | GPU (NVIDIA) | Ascend NPU |
+|-----------|-------------|------------------|
+| Grid nature | Logical task dimensions (decoupled from physical cores) | Physical core group mapping (bound to AI Core topology) |
+| Core count/dimension limits | No hard limits on grid dimensions/size | Grid size <= total AI Cores, and <= 65535 |
+| Parallelism model | Can bind multi-dimensional axes (3D grid), each thread executes once | Physical cores (Vector/Cube), each core executes one Block, supports repeated scheduling |
+| Memory access alignment | No mandatory requirements | VV scenarios: 32-byte alignment, CV scenarios: 512-byte alignment |
+| On-chip memory | Shared Memory | UB (Unified Buffer), 192KB for Atlas 800T/I A2 |
+
+### Core Migration Principles
+
+1. **Abandon GPU "free logical grid definition"**, switch to Ascend "physical core group binding"
+2. **Memory access alignment requirements**: 32-byte alignment for VV scenarios, 512-byte alignment for CV scenarios
+3. **Remove GPU-specific synchronization APIs**
+4. **Prefer 1D Grid**: 2D NPU adaptation will also be merged into 1D, actual grid values should align with chip physical core count
+   - For example: `(20,)` and `(4, 5)` have the same effect
+
+---
+
+## Complete Migration Example (Vector Addition)
+
+```diff
++ import torch_npu  # [NEW] Import Ascend NPU PyTorch adaptation library
+
+import triton
+import triton.language as tl
+
+- DEVICE = triton.runtime.driver.active.get_active_torch_device()  # [REMOVE] GPU device auto-detection
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    output = x + y
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+def add(x: torch.Tensor, y: torch.Tensor):
+    output = torch.empty_like(x)
+-   assert x.device == DEVICE and y.device == DEVICE  # [REMOVE] GPU device check
+    n_elements = output.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+    add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
+    return output
+
+torch.manual_seed(0)
+size = 98432
+- x = torch.rand(size, device='cuda')  # [BEFORE]
++ x = torch.rand(size, device='npu')   # [AFTER]
+- y = torch.rand(size, device='cuda')  # [BEFORE]
++ y = torch.rand(size, device='npu')   # [AFTER]
+
+output_torch = x + y
+output_triton = add(x, y)
+print(f'Max difference: {torch.max(torch.abs(output_torch - output_triton))}')
+```
+
+---
+
+## Data Tiling Strategy
+
+A reasonable data tiling strategy is critical for performance optimization. Common tiling parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `ncore` | Number of cores used (cross-core tiling) |
+| `xblock` | Inter-core data block size (inter-core tiling) |
+| `xblock_sub` | Intra-core tiling granularity (intra-core fine-grained partitioning) |
+
+### Efficient Triton Implementation Example (GELU Operator)
+
+```python
+@triton.jit
+def triton_better_kernel(in_ptr0, out_ptr0, xnumel,
+                         XBLOCK: tl.constexpr, XBLOCK_SUB: tl.constexpr):
+    # Inter-core tiling: each core processes XBLOCK-sized data
+    xoffset = tl.program_id(0) * XBLOCK
+
+    # Intra-core tiling: further divided into XBLOCK_SUB-sized chunks
+    for xoffset_sub in range(0, XBLOCK, XBLOCK_SUB):
+        x_index = xoffset + xoffset_sub + tl.arange(0, XBLOCK_SUB)[:]
+        xmask = x_index < xnumel
+        x = tl.load(in_ptr0 + x_index, xmask)
+        ret = x * 0.5 * (1.0 + tl.erf(x / tl.sqrt(2.0)))
+        tl.store(out_ptr0 + x_index, ret, xmask)
+
+# Call example
+ncore = 32
+xblock = 32768
+xblock_sub = 8192
+triton_better_kernel[ncore, 1, 1](x0, out1, x0.numel(), xblock, xblock_sub)
+```
+
+**Note**: The on-chip memory (UB) capacity of Atlas 800T/I A2 is **192KB**. When designing tiling strategies, ensure that the data volume per computation round does not exceed this limit.
+
+---
+
+## Common Issue Diagnosis and Resolution
+
+### Issue 1: coreDim Exceeding Limit
+
+**Error message**: `coreDim=xxxx can't be greater than UINT16_MAX`
+
+**Cause**: NPU's coreDim parameter cannot exceed 65535. When processing large-scale data, simple grid partitioning may cause this limit to be exceeded.
+
+**Solution 1**: Set environment variable (recommended)
+```bash
+export TRITON_ALL_BLOCKS_PARALLEL=1
+```
+When enabled, the compiler automatically adjusts the logical core count to match the physical core count, reducing scheduling overhead.
+
+**Solution 2**: Dynamically compute BLOCK_SIZE
+```python
+N = inp.numel()
+# Formula: coreDim = ceil(N / BLOCK_SIZE) <= 65535
+min_block_size = triton.next_power_of_2(triton.cdiv(N, 65535))
+BLOCK_SIZE = max(32768, min_block_size)  # At least 32768
+
+grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+kernel[grid_fn](out, N, BLOCK_SIZE=BLOCK_SIZE)
+```
+
+### Issue 2: UB Space Overflow
+
+**Error message**: `ub overflow, requires xxxx bits while 1572684 bits available!`
+
+**Cause**: Memory usage exceeds the NPU's UB cache capacity (192KB = 1572864 bits).
+
+**Solution**: Introduce BLOCK_SIZE_SUB parameter for block processing
+
+```python
+@triton.jit
+def kernel(inp, out, N, BLOCK_SIZE: tl.constexpr, BLOCK_SIZE_SUB: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    base_offset = pid * BLOCK_SIZE
+
+    # Block processing to avoid UB overflow
+    for sub_idx in range(tl.cdiv(BLOCK_SIZE, BLOCK_SIZE_SUB)):
+        sub_offset = base_offset + sub_idx * BLOCK_SIZE_SUB
+        offsets = sub_offset + tl.arange(0, BLOCK_SIZE_SUB)
+        mask = offsets < N
+        # Load and process data in batches
+        data = tl.load(inp + offsets, mask=mask, other=0)
+        result = process(data)
+        tl.store(out + offsets, result, mask=mask)
+
+# Call example
+MAIN_BLOCK_SIZE = 32768   # Ensure coreDim compliance
+SUB_BLOCK_SIZE = 1024     # Control UB usage
+grid = lambda meta: (triton.cdiv(N, MAIN_BLOCK_SIZE),)
+kernel[grid](inp, out, N, MAIN_BLOCK_SIZE, SUB_BLOCK_SIZE)
+```
+
+### Issue 3: Discrete Memory Access and Scalar Inefficient Mapping
+
+**Diagnostic method**:
+```bash
+export TRITON_DEBUG=1
+# View generated IR
+bishengir-compile xxx.ttadapter --target=Ascend910B3 \
+    --enable-auto-multi-buffer=True \
+    --enable-hfusion-compile=true \
+    --enable-hivm-compile=true \
+    --enable-triton-kernel-compile=true \
+    --hivm-compile-args=bishengir-print-ir-after=hivm-inject-sync
+```
+
+**Root cause**: For `[1024, 32]` 2D data, if stride is set to `(32,)` instead of `(32, 1)`, it causes non-contiguous memory access, degrading performance.
+
+**Optimization solution**: Adjust `block_ptr` shape/stride
+```python
+# Before optimization (inefficient)
+block_ptr = tl.make_block_ptr(
+    base=input_ptr,
+    shape=(1024,),
+    strides=(32,),      # Non-contiguous memory access
+    offsets=(i_t * 16,),
+    block_shape=(BT,),
+    order=(0,)
+)
+
+# After optimization (efficient)
+block_ptr = tl.make_block_ptr(
+    base=input_ptr,
+    shape=(1024, 32),
+    strides=(32, 1),    # Contiguous memory access
+    offsets=(i_t * BT, 0),
+    block_shape=(BT, 32),
+    order=(1, 0)        # Row-major order
+)
+```
+
+---
+
+## Performance Optimization Guide
+
+### 1. Grid Core Allocation Optimization
+
+When the Grid core count is large, use environment variables to improve performance:
+```bash
+export TRITON_ALL_BLOCKS_PARALLEL=1
+```
+
+### 2. Instruction-Level Parallelism Optimization
+
+#### Using `care_padding=False` to Reduce Synchronization
+
+When `tl.load` uses a mask, NPU by default fills default values with the Vector core first, then transfers data with MTE2, creating a dependency. Using `care_padding=False` removes the default value filling, improving parallelism:
+
+```python
+# Before optimization (with dependency)
+data = tl.load(input + idx, mask=mask)
+
+# After optimization (reduced dependency)
+data = tl.load(input + idx, mask=mask, care_padding=False)
+```
+
+**Applicable condition**: The unfilled portion does not affect subsequent computation results.
+
+#### Using For Loops to Increase Tiling
+
+Change single sequential execution to multiple block processing, enabling "data-in/compute/data-out" pipelining:
+
+```python
+# Before optimization: load all data at once
+offset = tl.arange(0, max_num_tokens)
+data = tl.load(ptr + offset, mask=offset < num)
+tl.store(out + offset, process(data), mask=offset < num)
+
+# After optimization: block processing
+BLOCK_SIZE = 1024
+num_loop = tl.cdiv(max_num_tokens, BLOCK_SIZE)
+blk_offset = tl.arange(0, BLOCK_SIZE)
+for i in range(num_loop):
+    offset = blk_offset + i * BLOCK_SIZE
+    data = tl.load(ptr + offset, mask=offset < num)
+    tl.store(out + offset, process(data), mask=offset < num)
+```
+
+### 3. Data Type Optimization
+
+The A2/A3 vector computation units do not support certain data types for some operations, causing fallback to scalar computation:
+
+| OP Name | Unsupported Data Types | Recommended Alternative |
+|---------|----------------------|------------------------|
+| Vector ADD | int64 | int32 |
+| Vector CMP | int64, int32 | float32 |
+
+**Example: Avoid int64/int32 for CMP operations**
+```python
+# Before optimization (inefficient)
+cols = tl.arange(0, BLOCK_N)  # cols is int64
+xbar = tl.where(cols < N, x - mean, 0.0)
+
+# After optimization (efficient)
+cols = tl.arange(0, BLOCK_N)
+cols_cmp = cols.to(tl.float32)  # Convert to float32
+xbar = tl.where(cols_cmp < N, x - mean, 0.0)
+```
+
+---
+
+## Compilation Optimization Options (Autotune Configuration)
+
+Pass compilation options in `triton.Config`:
+
+```python
+def get_autotune_config():
+    return [
+        triton.Config({'XS': 1 * 128, 'multibuffer': True}),
+    ]
+```
+
+### Available Options
+
+| Option | Capability | Default |
+|--------|-----------|---------|
+| `multibuffer` | Enable pipelined parallel data transfer | True |
+| `unit_flag` | Cube output optimization | None |
+| `limit_auto_multi_buffer_only_for_local_buffer` | CV operator optimization | None |
+| `limit_auto_multi_buffer_of_local_buffer` | Cube operator double buffer scope | None, options: `["no-limit", "no-l0c"]` |
+| `set_workspace_multibuffer` | Used with the above options | None, e.g., `[2,4]` |
+| `enable_hivm_auto_cv_balance` | CV balance optimization | None |
+| `tile_mix_vector_loop` | CV operator vector tiling count | None, e.g., `[2,4,8]` |
+| `tile_mix_cube_loop` | CV operator cube tiling count | None, e.g., `[2,4,8]` |
+
+**Note**: CV operators refer to operators that use both Cube Core and Vector Core during computation.
+
+---
+
+## Concurrent Task Count Configuration Recommendations
+
+Ascend NPU has multiple compute cores (AI Cores), including Cube Cores (matrix multiplication) and Vector Cores (vector computation).
+
+| Operator Type | Concurrent Task Count Configuration |
+|--------------|-------------------------------------|
+| Vector-only operators (no `tl.dot`) | Concurrent tasks = Vector Core count |
+| Operators with `tl.dot` | Concurrent tasks = AI Core count |
+
+Get physical core count:
+```python
+from triton.runtime import driver
+properties = driver.active.utils.get_device_properties()
+```
+
+**Notes**:
+- When concurrent task count > physical core count, batch scheduling occurs, incurring additional overhead
+- Maximum concurrent task count cannot exceed 65535


### PR DESCRIPTION
## Changes

- Rename generation sub-skills for consistency:
  - `kernelgen-general.md` → `kernelgen-generate.md`
  - `kernelgen-for-flaggems.md` → `kernelgen-generate-for-flaggems.md`
  - `kernelgen-for-vllm.md` → `kernelgen-generate-for-vllm.md`

- Add optimize sub-skills (3 new files):
  - `kernelgen-optimize.md` — General-purpose Triton kernel optimization
  - `kernelgen-optimize-for-flaggems.md` — FlagGems-specific optimization
  - `kernelgen-optimize-for-vllm.md` — vLLM-specific optimization

- Add specialize sub-skills (2 new files):
  - `kernelgen-specialize.md` — Platform specialization (GPU → Ascend NPU)
  - `kernelgen-specialize-for-flaggems.md` — FlagGems + platform specialization

- Update SKILL.md, README.md, README_zh.md with new file references